### PR TITLE
Improve db search

### DIFF
--- a/Scripts/.gitignore
+++ b/Scripts/.gitignore
@@ -1,0 +1,1 @@
+BuildDatabank/search-databank-pairs.log

--- a/Scripts/BuildDatabank/searchDATABANK.py
+++ b/Scripts/BuildDatabank/searchDATABANK.py
@@ -226,7 +226,7 @@ def loadExperiments(experimentType):
           
     return experiments
     
-def findPairs(experiments):
+def findPairs(experiments, simulations):
     pairs = []
     for simulation in simulations:
         sim_lipids = simulation.getLipids()
@@ -327,41 +327,42 @@ def findPairs(experiments):
             yaml.dump(simulation.readme,f, sort_keys=False)
         
     return pairs
-                        
-##############################################
-#loop over the simulations in the simulation databank and read simulation readme and order parameter files into objects
-simulations = loadSimulations()
-for simulation in simulations:
-    simulation.readme['EXPERIMENT'] = {}
-    simulation.readme['EXPERIMENT']['ORDERPARAMETER']= {}
-    simulation.readme['EXPERIMENT']['FORMFACTOR']= {}
-    for lipid in simulation.getLipids():
-        simulation.readme['EXPERIMENT']['ORDERPARAMETER'][lipid] = {}
-    
-   # print(simulation.indexingPath)
+
+def main():
+    """
+    Main program function. Not for exporting.
+    """
+
+    simulations = loadSimulations()
+
+    # clear all EXPERIMENT sections in all simulations
+    for simulation in simulations:
+        simulation.readme['EXPERIMENT'] = {}
+        simulation.readme['EXPERIMENT']['ORDERPARAMETER']= {}
+        simulation.readme['EXPERIMENT']['FORMFACTOR']= {}
+        for lipid in simulation.getLipids():
+            simulation.readme['EXPERIMENT']['ORDERPARAMETER'][lipid] = {}
         
-    outfileDICT = os.path.join(databank_path, simulation.indexingPath, 'README.yaml')
-    with open(outfileDICT, 'w') as f:
-        yaml.dump(simulation.readme,f, sort_keys=False)
+        outfileDICT = os.path.join(databank_path, simulation.indexingPath, 'README.yaml')
+        with open(outfileDICT, 'w') as f:
+            yaml.dump(simulation.readme, f, sort_keys=False)
 
-#load experiments
-experimentsOrderParameters = loadExperiments('OrderParameters')
-experimentsFormFactors = loadExperiments('FormFactors')
+    experimentsOrderParameters = loadExperiments('OrderParameters')
+    experimentsFormFactors = loadExperiments('FormFactors')
 
+    # Pair each simulation with an experiment with the closest matching temperature and composition
+    pairsOP = findPairs(experimentsOrderParameters, simulations)
+    pairsFF = findPairs(experimentsFormFactors, simulations)
 
-#Pair each simulation with an experiment with the closest matching temperature and composition
-pairsOP = findPairs(experimentsOrderParameters)
-pairsFF = findPairs(experimentsFormFactors)
+    for pair in pairsFF:
+        print('#################')
+        print(pair[0].readme)
+        print(pair[0].indexingPath)
+        print("#")
+        print(pair[1].readme)         
 
-#print(experimentsOrderParameters)
-#print(len(simulations))
+    print("Found order parameter data for " + str(len(pairsOP)) + " pairs")  
+    print("Found form factor data for " + str(len(pairsFF)) + " pairs")
 
-for pair in pairsFF:
-    print('#################')
-    print(pair[0].readme)
-    print(pair[0].indexingPath)
-    print("#")
-    print(pair[1].readme)         
-
-print("Found order parameter data for " + str(len(pairsOP)) + " pairs")  
-print("Found form factor data for " + str(len(pairsFF)) + " pairs")
+if __name__ == "__main__":
+    main()

--- a/Scripts/BuildDatabank/searchDATABANK.py
+++ b/Scripts/BuildDatabank/searchDATABANK.py
@@ -1,14 +1,9 @@
 import os
 import yaml
 import json
-import matplotlib.pyplot as plt
-import numpy as np
-import math
-
-from matplotlib import cm
-from scipy.stats import norm
 
 from databankLibrary import lipids_dict
+from tqdm import tqdm
 
 databank_path = '../../Data/Simulations'
 
@@ -305,8 +300,16 @@ def findPairs(experiments):
                             simulation.readme['EXPERIMENT']['FORMFACTOR']=exp_path
                     else:
                         continue
+        
+        # sorting experiment lists to keep experimental order strict
+        for _lipid in simulation.readme['EXPERIMENT']['ORDERPARAMETER'].keys():
+            unsortDict = simulation.readme['EXPERIMENT']['ORDERPARAMETER'][_lipid].copy()
+            if not len(unsortDict):
+                continue
+            sortDict = dict(sorted(unsortDict.items()))
+            simulation.readme['EXPERIMENT']['ORDERPARAMETER'][_lipid] = sortDict.copy()
+
         outfileDICT = '../../Data/Simulations/'+ simulation.indexingPath + '/README.yaml'
-    
         with open(outfileDICT, 'w') as f:
             yaml.dump(simulation.readme,f, sort_keys=False)
         f.close()

--- a/Scripts/BuildDatabank/searchDATABANK.py
+++ b/Scripts/BuildDatabank/searchDATABANK.py
@@ -225,7 +225,7 @@ def loadExperiments(experimentType):
                 experiments.append(Experiment(readmeExp, expData, subdir, experimentType))
           
     return experiments
-    
+ 
 def findPairs(experiments, simulations):
     pairs = []
     for simulation in tqdm(simulations, desc='Simulation'):
@@ -319,6 +319,37 @@ def findPairs(experiments, simulations):
         
     return pairs
 
+def logPairs(pairs, fd):
+    """
+    Write found correspondences into log file.
+
+    pairs: [(Simulation, Experiment), ...]
+    fd: file descriptor for writting into
+    """
+
+    for p in pairs:
+        sim : Simulation = p[0]
+        exp : Experiment = p[1]
+
+        sysn = sim.readme['SYSTEM']
+        simp = sim.indexingPath
+
+        expp = exp.dataPath
+        expd = exp.readme['DOI']
+
+        fd.write(f"""
+--------------------------------------------------------------------------------
+Simulation:
+ - {sysn}
+ - {simp}
+Experiment:
+ - {expd}
+ - {expp}""")
+        # end for
+    fd.write("""
+--------------------------------------------------------------------------------
+    \n""")
+
 def main():
     """
     Main program function. Not for exporting.
@@ -342,10 +373,15 @@ def main():
     experimentsFormFactors = loadExperiments('FormFactors')
 
     # Pair each simulation with an experiment with the closest matching temperature and composition
-    print("Scanning simulation-experiment pairs among order parameter experiments.")
-    pairsOP = findPairs(experimentsOrderParameters, simulations)
-    print("Scanning simulation-experiment pairs among form factor experiments.")
-    pairsFF = findPairs(experimentsFormFactors, simulations)
+    with open('search-databank-pairs.log', 'w') as logf:
+        print("Scanning simulation-experiment pairs among order parameter experiments.")
+        pairsOP = findPairs(experimentsOrderParameters, simulations)
+        logf.write("=== OP PAIRS ===\n")
+        logPairs(pairsOP, logf)
+        print("Scanning simulation-experiment pairs among form factor experiments.")
+        pairsFF = findPairs(experimentsFormFactors, simulations)
+        logf.write("=== FF PAIRS ===\n")
+        logPairs(pairsFF, logf)
 
     '''
     for pair in pairsFF:


### PR DESCRIPTION
I have done a lot for this file. 
1) fixed issue #162  with ordering experiments
2) Improved the interface: now there are progress bars everywhere
3) Add logging: now it logs matched pairs to the file instead of output
4) fixed path arithmetics: now it's based on `os.path.join`, `os.path.relpath` instead `of a + '/' + b` ...
5) fixed weird code and general style, shortened strings, removed unused comments, added some comments, etc