### PR TITLE
Seperate info file processing from global methods on simulations

### DIFF
--- a/Scripts/WorkflowScripts/ProcessInfoFile.py
+++ b/Scripts/WorkflowScripts/ProcessInfoFile.py
@@ -25,9 +25,6 @@ def main(info_file_path):
         "Calcproperties failed",
         working_dir=path_dict["AnalyzeDatabank_path"]
     )
-    run_python_script(path_dict["searchDATABANK_path"], error_message="SearchDatabank failed")
-    run_python_script(path_dict["QualityEvaluation_path"], error_message="QualityEvaluation failed")
-    run_python_script(path_dict["makeRanking_path"], error_message="makeRanking failed")
     delete_info_file(info_file_path)
 
 #Gets arguments from parser

--- a/Scripts/WorkflowScripts/RunAnalysis.py
+++ b/Scripts/WorkflowScripts/RunAnalysis.py
@@ -1,0 +1,18 @@
+from DatabankLib import NMLDB_ROOT_PATH
+from WorkflowScripts.Workflow_utils import *  
+"""
+Executes pipeline of analysis methods that work globally on simulations.
+
+.. note::
+   This file is only meant to be used by automated workflows.
+   Users of the Databank repository can safely ignore it.
+"""
+
+def main():    
+    path_dict = get_databank_paths(NMLDB_ROOT_PATH)
+    run_python_script(path_dict["searchDATABANK_path"], error_message="SearchDatabank failed")
+    run_python_script(path_dict["QualityEvaluation_path"], error_message="QualityEvaluation failed")
+    run_python_script(path_dict["makeRanking_path"], error_message="makeRanking failed")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Separating scripts that make global changes from those that only update files for new simulations.

This is done to reduces the chance of merge conflicts when multiple simulations are added to the data repository via website prior to them getting merged. 