### PR TITLE
Add workflow to build docker images monthly 

### DIFF
--- a/.github/workflows/BuildDockerImages.yml
+++ b/.github/workflows/BuildDockerImages.yml
@@ -9,26 +9,13 @@ jobs:
   build_gromacs:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout GROMACS repo
-        uses: actions/checkout@v4
-        with:
-          repository: gromacs/gromacs
-          fetch-depth: 0
-          path: gromacs-src
-
-
-      - name: Get previous tag
-        id: tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-        with: 
-          workingDirectory: gromacs-src
-     
-      - name: Strip leading 'v'
+      - name: Get latest gromacs release version 
         id: version
-        shell: bash
         run: |
-            TAG="${{ steps.tag.outputs.tag }}"
-            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+            set -euo pipefail
+            tag="$(curl -fsSL "https://gitlab.com/api/v4/projects/gromacs%2Fgromacs/releases/permalink/latest" | jq -r .tag_name)"
+            echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+            echo "Latest tag: $tag" 
         
       - name: Checkout Databank repo
         uses: actions/checkout@v4
@@ -37,7 +24,7 @@ jobs:
         run: |
           docker build \
             -f Scripts/Docker/gromacs \
-            -t nmrlipids/gromacs:${{ steps.tag.outputs.tag }} \
+            -t nmrlipids/gromacs \
             --build-arg GROMACS_VERSION=${{ steps.version.outputs.version }} \
             .
 
@@ -49,21 +36,18 @@ jobs:
 
       - name: Push gromacs image
         run: |
-          docker push nmrlipids/gromacs:${{ steps.tag.outputs.tag }}
+          docker push nmrlipids/gromacs
 
   build_core:
     runs-on: ubuntu-latest
     needs: build_gromacs
     steps:
-      - name: Checkout Databank repo
+      - name: Checkout Databank repo 
         uses: actions/checkout@v4
 
       - name: Build core image
         run: |
-          docker build \
-            -f Scripts/Docker/core \
-            -t nmrlipids/core:latest \
-            .
+          docker build -f Scripts/Docker/core -t nmrlipids/core .
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -72,6 +56,5 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push core image
-        run: |
-          docker push nmrlipids/core:latest
+        run: docker push nmrlipids/core
 

--- a/.github/workflows/BuildDockerImages.yml
+++ b/.github/workflows/BuildDockerImages.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build_gromacs:
     runs-on: ubuntu-latest
+    if: github.repository == 'NMRLipids/Databank'
     steps:
       - name: Get latest gromacs release version 
         id: version
@@ -58,3 +59,22 @@ jobs:
       - name: Push core image
         run: docker push nmrlipids/core
 
+  build_doc_builder:
+     runs-on: ubuntu-latest
+     if: github.repository == 'NMRLipids/Databank'
+     steps:
+      - name: Checkout Databank repo 
+        uses: actions/checkout@v4
+
+      - name: Build doc-builder image
+        run: |
+          docker build -f Scripts/Docker/doc-builder -t nmrlipids/doc-builder .
+              
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Push doc-builder image
+        run: docker push nmrlipids/doc-builder

--- a/.github/workflows/BuildDockerImages.yml
+++ b/.github/workflows/BuildDockerImages.yml
@@ -1,0 +1,77 @@
+name: Build Docker Images
+on:
+  schedule:
+    - cron: "0 4 1 * *"
+  
+  workflow_dispatch:
+
+jobs:
+  build_gromacs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GROMACS repo
+        uses: actions/checkout@v4
+        with:
+          repository: gromacs/gromacs
+          fetch-depth: 0
+          path: gromacs-src
+
+
+      - name: Get previous tag
+        id: tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with: 
+          workingDirectory: gromacs-src
+     
+      - name: Strip leading 'v'
+        id: version
+        shell: bash
+        run: |
+            TAG="${{ steps.tag.outputs.tag }}"
+            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+        
+      - name: Checkout Databank repo
+        uses: actions/checkout@v4
+
+      - name: Build gromacs image
+        run: |
+          docker build \
+            -f Scripts/Docker/gromacs \
+            -t nmrlipids/gromacs:${{ steps.tag.outputs.tag }} \
+            --build-arg GROMACS_VERSION=${{ steps.version.outputs.version }} \
+            .
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Push gromacs image
+        run: |
+          docker push nmrlipids/gromacs:${{ steps.tag.outputs.tag }}
+
+  build_core:
+    runs-on: ubuntu-latest
+    needs: build_gromacs
+    steps:
+      - name: Checkout Databank repo
+        uses: actions/checkout@v4
+
+      - name: Build core image
+        run: |
+          docker build \
+            -f Scripts/Docker/core \
+            -t nmrlipids/core:latest \
+            .
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Push core image
+        run: |
+          docker push nmrlipids/core:latest
+

--- a/.github/workflows/BuildDockerImages.yml
+++ b/.github/workflows/BuildDockerImages.yml
@@ -6,10 +6,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_gromacs:
+  build_gromacs_and_core:
     runs-on: ubuntu-latest
     if: github.repository == 'NMRLipids/Databank'
     steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Get latest gromacs release version 
         id: version
         run: |
@@ -28,33 +34,13 @@ jobs:
             -t nmrlipids/gromacs \
             --build-arg GROMACS_VERSION=${{ steps.version.outputs.version }} \
             .
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Push gromacs image
         run: |
           docker push nmrlipids/gromacs
 
-  build_core:
-    runs-on: ubuntu-latest
-    needs: build_gromacs
-    steps:
-      - name: Checkout Databank repo 
-        uses: actions/checkout@v4
-
       - name: Build core image
         run: |
           docker build -f Scripts/Docker/core -t nmrlipids/core .
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push core image
         run: docker push nmrlipids/core
@@ -63,18 +49,18 @@ jobs:
      runs-on: ubuntu-latest
      if: github.repository == 'NMRLipids/Databank'
      steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          
       - name: Checkout Databank repo 
         uses: actions/checkout@v4
 
       - name: Build doc-builder image
         run: |
           docker build -f Scripts/Docker/doc-builder -t nmrlipids/doc-builder .
-              
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push doc-builder image
         run: docker push nmrlipids/doc-builder

--- a/Scripts/BuildDocs/requirements-docs.txt
+++ b/Scripts/BuildDocs/requirements-docs.txt
@@ -1,0 +1,2 @@
+myst-parser 
+sphinx-rtd-theme 

--- a/Scripts/Docker/core
+++ b/Scripts/Docker/core
@@ -18,12 +18,16 @@ RUN apt-get update && \
       python3.11-venv \
       python3-pip \
       ca-certificates && \
-    rm -rf /var/lib/apt/lists/* && \
-    python3.11 -m venv /opt/venv && \
-    /opt/venv/bin/pip install --upgrade pip && \
-    chmod -R a+rwX /opt/venv
+    rm -rf /var/lib/apt/lists/* 
 
-# Create runner group & user, then own the venv
+# Create python virtual environment and set permissions    
+RUN python3.11 -m venv /opt/venv && \
+    export PATH=/opt/venv/bin:$PATH && \
+    pip install --upgrade pip && \
+    pip install --no-cache-dir -r /tmp/requirements-dev.txt && \
+    chmod -R 777 /opt/venv
+
+# Create runner group & user
 RUN groupadd --gid ${RUNNER_GID} runner && \
     useradd --uid ${RUNNER_UID} --gid runner --create-home --shell /bin/bash runner 
 
@@ -31,8 +35,6 @@ RUN groupadd --gid ${RUNNER_GID} runner && \
 ENV PATH="/opt/venv/bin:/usr/local/gromacs/bin:${PATH}"
 
 USER runner
-# Install dev requirements into the venv
-RUN pip install --no-cache-dir -r /tmp/requirements-dev.txt
 
 WORKDIR /github/workspace
 

--- a/Scripts/Docker/doc-builder
+++ b/Scripts/Docker/doc-builder
@@ -1,0 +1,6 @@
+FROM debian:bookworm-slim
+
+COPY Scripts/DatabankLib/requirements.txt requirements.txt 
+COPY Scripts/BuildDocs/requirements-docs.txt requirements-docs.txt
+RUN apt-get update && apt-get install -y     git     make     wget     python3     python3-pip 
+RUN pip3 install --no-cache-dir --break-system-packages -r requirements.txt -r requirements-docs.txt


### PR DESCRIPTION
Workflow related PR which includes:

* Adds workflow that builds and pushes each of the docker images currently in use. 
* Adds dockerfile for the doc-builder image that is currently in use
* Fixes small permission problem in core image

The builds without dependencies are run in parallel. The jobs for building gromacs and the core image can be combined if we want a bit less code duplication at the cost of slightly messier logs. 

Edit: I added a commit combining the jobs.

Closes #307 