### PR TITLE
Allow MAICoS to work with dummy atom

### DIFF
--- a/Scripts/DatabankLib/maicos.py
+++ b/Scripts/DatabankLib/maicos.py
@@ -6,8 +6,40 @@ from maicos.lib.weights import density_weights
 import numpy as np
 import MDAnalysis as mda
 
-from .jsonEncoders import CompactJSONEncoder
+from DatabankLib.core import System
+from DatabankLib.jsonEncoders import CompactJSONEncoder
 
+
+def is_system_suitable_4_maicos(system: System):
+    """
+Checks if the system is suitable for maicos calculations."
+
+    :param system: Databank System object (System)
+    :return: False if system should be skipped
+    """
+    if system['TYPEOFSYSTEM'] == 'miscellaneous':
+        return False
+    try:
+        if system['WARNINGS']['ORIENTATION']:
+            print('Skipping due to ORIENTATION warning:',
+                  system['WARNINGS']['ORIENTATION'])
+            return False
+    except (KeyError, TypeError):
+        pass
+    try:
+        if system['WARNINGS']['PBC'] == 'hexagonal-box':
+            print('Skipping due to PBC warning:', system['WARNINGS']['PBC'])
+            return False
+    except (KeyError, TypeError):
+        pass
+    try:
+        if system['WARNINGS']['NOWATER']:
+            print('Skipping because there is not water in the trajectory.')
+            return False
+    except (KeyError, TypeError):
+        pass
+    return True
+ 
 
 class NumpyArrayEncoder(CompactJSONEncoder):
     """Encoder for 2xN numpy arrays to be used with json.dump."""

--- a/Scripts/DatabankLib/settings/elements.py
+++ b/Scripts/DatabankLib/settings/elements.py
@@ -28,11 +28,12 @@ def uname2element(mapping_name: str):
 
     if name2 == "G":  # G is a glycerol carbon so change G to C
         name2 = "C"
+    elif name2 == "X":  # X is a placeholder for unknown element, we use 'X' as element name
+        name2 = "Dummy"  # Dummy is used for unknown elements in MDAnalysis
+        return name2
 
     try:
-        if name2 != "X":
-            # X is a placeholder for unknown element, we use 'X' as element name
-            _ = getattr(periodictable, name2).number
+        _ = getattr(periodictable, name2).number
     except AttributeError as e:
         raise KeyError(
             "This mapping name cannot be read by our rules: {mapping_name}") from e

--- a/Scripts/DatabankLib/settings/elements.py
+++ b/Scripts/DatabankLib/settings/elements.py
@@ -30,12 +30,14 @@ def uname2element(mapping_name: str):
         name2 = "C"
 
     try:
-        _ = getattr(periodictable, name2).number
+        if name2 != "X":
+            # X is a placeholder for unknown element, we use 'X' as element name
+            _ = getattr(periodictable, name2).number
     except AttributeError as e:
         raise KeyError(
             "This mapping name cannot be read by our rules: {mapping_name}") from e
-
-    return name2
+    else:
+        return name2
 
 
 def guess_elements(system: System, u: mda.Universe) -> None:

--- a/Scripts/tests/test_api.py
+++ b/Scripts/tests/test_api.py
@@ -6,11 +6,6 @@ files and precomputed JSON data.
 Test data is stored in `./Data/Simulations.2`
 
 -------------------------------------------------------------------------------
-Currently, we do mocking of NMLDB_SIMU_PATH and it requires to be done once
-during pytest session. That's why we name this file "test2_api.py" because
-it avoids `pytest` from executing it together with other "test_*.py" files.
-Probably the problem can be solved using importlib and updating import specs.
-
 NOTE: globally import of DatabankLib is **STRICTLY FORBIDDEN** because it 
       breaks the substitution of global path folders
 """

--- a/Scripts/tests/test_misc.py
+++ b/Scripts/tests/test_misc.py
@@ -1,0 +1,27 @@
+"""
+`test_misc` contains unit tests of auxiliary functions.
+Test data is stored in `./Data/Simulations.2`
+
+-------------------------------------------------------------------------------
+NOTE: globally import of DatabankLib is **STRICTLY FORBIDDEN** because it 
+      breaks the substitution of global path folders
+"""
+
+import pytest
+import pytest_check as check
+
+# run only on sim2 mocking data
+pytestmark = pytest.mark.nodata
+
+
+def test_uname2element():
+    """Test uname2element function."""
+    from DatabankLib.settings.elements import uname2element
+
+    check.equal(uname2element("M_C1_M"), "C")
+    check.equal(uname2element("M_G1_M"), "C")
+    check.equal(uname2element("M_C1N3_M"), "N")
+    check.equal(uname2element("M_X_M"), "X")
+
+    with pytest.raises(KeyError):
+        uname2element("UnknownElement")

--- a/Scripts/tests/test_misc.py
+++ b/Scripts/tests/test_misc.py
@@ -7,6 +7,7 @@ NOTE: globally import of DatabankLib is **STRICTLY FORBIDDEN** because it
       breaks the substitution of global path folders
 """
 
+import os
 import pytest
 import pytest_check as check
 
@@ -25,3 +26,61 @@ def test_uname2element():
 
     with pytest.raises(KeyError):
         uname2element("UnknownElement")
+
+
+def test_maicos_interface(tmpdir):
+    import MDAnalysis as mda
+    from MDAnalysis.coordinates.memory import MemoryReader
+    from DatabankLib.maicos import DensityPlanar
+    import numpy as np
+
+    folder = str(tmpdir)
+    # Skip unwrap/pack for speed - trajectories are already centered and whole
+    base_options = {"unwrap": False, "bin_width": 1, "pack": False}
+    zlim = {"zmin": 0, "zmax": 8.67623}
+    dens_options = {**zlim, **base_options}
+
+    pdb_content = \
+"""TITLE     Single 4-site water
+CRYST1   63.646   63.646   86.762  90.00  90.00  90.00 P 1           1
+ATOM      1  OW  wate    1       4.370  31.010  61.030  1.00  0.00            
+ATOM      2  HW1 wate    1       3.800  30.820  61.780  1.00  0.00            
+ATOM      3  HW2 wate    1       5.250  30.760  61.320  1.00  0.00            
+ATOM      4  MW  wate    1       4.410  30.950  61.170  1.00  0.00  
+END
+"""
+    tmpfile = os.path.join(folder, "test_water_maicos.pdb")
+    with open(tmpfile, 'w') as f:
+        f.write(pdb_content)
+    u = mda.Universe(
+        tmpfile,
+        format="PDB",
+    )
+    nul_dim = u.dimensions
+    # Store coordinates for each frame
+    n_frames = 10
+    trajectory = np.zeros((n_frames, u.atoms.n_atoms, 3), dtype=np.float32)
+
+    for i in range(n_frames):
+        coords = u.atoms.positions.copy()
+        # move all atoms a little bit in x direction
+        coords = np.add(coords, [0.1 * i, 0.0, 0.0])  
+        trajectory[i] = coords
+
+    # Assign trajectory to Universe
+    u.load_new(trajectory, order='fac', format=MemoryReader)
+    for ts in u.trajectory:
+        ts.dimensions = nul_dim
+    # Now we are done!
+    u.add_TopologyAttr("elements")
+    u.atoms.elements = ['O', 'H', 'H', 'X']  # Assign elements manually
+
+    # Simulate MAICoS calls
+    cos_water = DensityPlanar(
+        u.atoms,
+        dens="electron",
+        **dens_options,
+        output=os.path.join(folder, "DiporderWater.json"),
+    )
+    cos_water.run()
+    assert True


### PR DESCRIPTION
MAICoS should process dummy atoms properly. If it has a charge, it should probably process the charge to compute the dipole moment. But if we compute electron density, a dummy element should be introduced. I think, it could be 'X'. It could be also empty string ''. But 'X' is safer because '' is unclear if it is just unset or it's dummy.

I wrote small unit-test which tests maicos integration on a dummy on-the-fly-created trajectory. 
@PicoCentauri, let's modify PR to pass these tests.

I mention @hsantila here because I'm actually not understanding what happened in the previous version with dummy atoms. We have at least two mapping files with dummies, and these dummies are named in a completely different way: D1, D2 in one and Vi in the other. I don't see any signs of code parts that deal somehow with these dummy atoms. I would consider all the form-factor data for all trajectories related to these water molecules to be corrupted and **required to be immediately deleted** from the BilayerData. 

In the end, it will close #311 and #312, probably too.