### PR TITLE
Retry with exponential backoff

### DIFF
--- a/Scripts/DatabankLib/databankio.py
+++ b/Scripts/DatabankLib/databankio.py
@@ -19,66 +19,138 @@ from typing import Mapping
 import urllib.error
 from tqdm import tqdm
 import urllib.request
+import functools
 
 logger = logging.getLogger(__name__)
 MAX_DRYRUN_SIZE = 50 * 1024 * 1024  # 50 MB, max size for dry-run download
 
+def retry_with_exponential_backoff(max_attempts=3, delay_seconds=1):
+    """
+    Decorator that retries a function with exponential backoff for transient network errors.
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            attempts = 0
+            current_delay = delay_seconds
+            while attempts < max_attempts:
+                try:
+                    return func(*args, **kwargs)
+                
+                # --- New logic to handle non-retriable HTTP client errors ---
+                except urllib.error.HTTPError as e:
+                    # Check if the error is a client error (4xx) which is not likely to be resolved by a retry.
+                    if 400 <= e.code < 500:
+                        logger.error(
+                            f"Function {func.__name__} failed with non-retriable client error {e.code}: {e.reason}"
+                        )
+                        raise e  # Re-raise the HTTPError immediately
+                    
+                    # For other errors (like 5xx server errors), proceed with retry logic.
+                    logger.warning(f"Caught retriable HTTPError {e.code}. Proceeding with retry...")
+                    # Fall through to the generic exception handling below.
+                
+                except (urllib.error.URLError, socket.timeout) as e:
+                    # This block now primarily handles non-HTTP errors or retriable HTTP errors.
+                    pass # Fall through to the retry logic below
+
+                # --- Existing retry logic ---
+                attempts += 1
+                if attempts < max_attempts:
+                    logger.warning(
+                        f"Attempt {attempts}/{max_attempts} for {func.__name__} failed. "
+                        f"Retrying in {current_delay:.1f} seconds..."
+                    )
+                    time.sleep(current_delay)
+                    current_delay *= 2
+                else:
+                    logger.error(
+                        f"Function {func.__name__} failed after {max_attempts} attempts."
+                    )
+                    # Re-raise the last exception caught to be handled by the caller
+                    raise ConnectionError(
+                        f"Function {func.__name__} failed after {max_attempts} attempts."
+                    )
+        return wrapper
+    return decorator
+
+# --- Decorated Helper Functions for Network Requests ---
+
+@retry_with_exponential_backoff(max_attempts=5, delay_seconds=2)
+def _open_url_with_retry(uri: str, timeout: int = 10):
+    """
+    A private helper to open a URL with a timeout and retry logic.
+    Returns the response object.
+    """
+    return urllib.request.urlopen(uri, timeout=timeout)
+
+@retry_with_exponential_backoff(max_attempts=5, delay_seconds=2)
+def get_file_size_with_retry(uri: str) -> int:
+    """Fetches the size of a file from a URI with retry logic."""
+    with _open_url_with_retry(uri) as response:
+        content_length = response.getheader('Content-Length')
+        return int(content_length) if content_length else 0
+
+@retry_with_exponential_backoff(max_attempts=5, delay_seconds=2)
+def download_with_progress_with_retry(uri: str, dest: str, fi_name: str) -> None:
+    """Downloads a file with a progress bar and retry logic."""
+    class RetrieveProgressBar(tqdm):
+        def update_retrieve(self, b=1, bsize=1, tsize=None):
+            if tsize is not None:
+                self.total = tsize
+            return self.update(b * bsize - self.n)
+
+    with RetrieveProgressBar(
+        unit="B", unit_scale=True, unit_divisor=1024, miniters=1, desc=fi_name
+    ) as u:
+        urllib.request.urlretrieve(uri, dest, reporthook=u.update_retrieve)
+
+# --- Main Functions ---
 
 def download_resource_from_uri(
     uri: str, dest: str, override_if_exists: bool = False,
     dry_run_mode: bool = False
 ) -> int:
     """
-    Download file resource [from uri] to given file destination using urllib
-
+    Download file resource from uri to given file destination using urllib.
+    
     :param uri: (str) file URL
     :param dest: (str) file destination path
-    :param override_if_exists: (bool, optional)
-            Override dest. file if exists. Defaults to False.
-
-    :raises HTTPException: An error occured during download
-
-    :return: code (int) 
-             0 - OK, 1 - skipped, 2 - redownloaded
+    :param override_if_exists: (bool, optional) Override dest. file if exists. Defaults to False.
+    
+    :raises ConnectionError: An error occurred after multiple download attempts.
+    
+    :return: code (int) 0 - OK, 1 - skipped, 2 - redownloaded
     """
-    # TODO verify file size before skipping already existing download!
-
-    class RetrieveProgressBar(tqdm):
-        # uses tqdm.update(), see docs https://github.com/tqdm/tqdm#hooks-and-callbacks
-        def update_retrieve(self, b=1, bsize=1, tsize=None):
-            if tsize is not None:
-                self.total = tsize
-            return self.update(b * bsize - self.n)
-
     fi_name = uri.split("/")[-1]
 
-    # check if dest path already exists
+    # Check if dest path already exists and compare file size
     if not override_if_exists and os.path.isfile(dest):
-        socket.setdefaulttimeout(10)  # seconds
-
-        # compare filesize
-        fi_size = urllib.request.urlopen(uri).length  # download size
-        if fi_size == os.path.getsize(dest):
-            logger.info(f"{dest}: file already exists, skipping")
-            return 1
-        else:
-            logger.warning(
-                f"{fi_name} filesize mismatch of local "
-                f"file '{fi_name}', redownloading ..."
+        try:
+            fi_size = get_file_size_with_retry(uri)
+            if fi_size == os.path.getsize(dest):
+                logger.info(f"{dest}: file already exists, skipping")
+                return 1
+            else:
+                logger.warning(
+                    f"{fi_name} filesize mismatch of local file '{fi_name}', redownloading ..."
+                )
+                return 2
+        except (ConnectionError, FileNotFoundError) as e:
+            logger.error(
+                f"Failed to verify file size for {fi_name}: {e}. Proceeding with redownload."
             )
             return 2
-
-    # download
-    socket.setdefaulttimeout(10)  # seconds
-    url_size = urllib.request.urlopen(uri).length  # download size
-
+    
+    # Download file in dry run mode
     if dry_run_mode:
-        # Download only up to MAX_DRYRUN_SIZE bytes, no tqdm
-        with urllib.request.urlopen(uri) as response, open(dest, "wb") as out_file:
+        url_size = get_file_size_with_retry(uri)
+        # Use the decorated helper for opening the URL
+        with _open_url_with_retry(uri) as response, open(dest, "wb") as out_file:
             total = min(url_size, MAX_DRYRUN_SIZE) if url_size else MAX_DRYRUN_SIZE
             downloaded = 0
             chunk_size = 8192
-            next_report = 10 * 1024 * 1024  # print every 10 MB
+            next_report = 10 * 1024 * 1024
             logger.info(
                 "Dry-run: Downloading up to"
                 f" {total // (1024*1024)} MB of {fi_name} ...")
@@ -97,39 +169,48 @@ def download_resource_from_uri(
                 f" {downloaded // (1024*1024)} MB of {fi_name}")
         return 0
 
-    with RetrieveProgressBar(
-        unit="B", unit_scale=True, unit_divisor=1024, miniters=1, desc=fi_name
-    ) as u:
-        _ = urllib.request.urlretrieve(uri, dest, reporthook=u.update_retrieve)
+    # Download with progress bar and check for final size match
+    url_size = get_file_size_with_retry(uri)
+    download_with_progress_with_retry(uri, dest, fi_name)
 
-    # check if the file is fully downloaded
     size = os.path.getsize(dest)
-
-    if url_size != size:
-        raise Exception(f"downloaded filsize mismatch ({size}/{url_size} B)")
-
+    if url_size != 0 and url_size != size:
+        raise OSError(f"Downloaded filesize mismatch ({size}/{url_size} B)")
+    
     return 0
-
 
 def resolve_doi_url(doi: str, validate_uri: bool = True) -> str:
     """
-    :meta private:
-    Returns full doi link of given ressource, also checks if URL is valid.
+    Returns the full DOI URL and validates that it is a reachable address.
 
-    Args:
-        doi (str): [doi] part from config
-        validate_uri (bool, optional): Check if URL is valid. Defaults to True.
+    :param doi: (str) The DOI identifier (e.g., "10.5281/zenodo.1234")
+    :param validate_uri: (bool, optional) If True, checks if the URL is valid. Defaults to True.
 
-    Returns:
-        str: full doi link
+    :raises urllib.error.HTTPError: If the DOI resolves to a URL, but the server returns an
+                                    HTTP error code (e.g., 404 Not Found).
+    :raises ConnectionError: If the server cannot be reached after multiple retries.
+    
+    :return: (str) The full, validated DOI link.
     """
     res = "https://doi.org/" + doi
 
     if validate_uri:
-        socket.setdefaulttimeout(10)  # seconds
-        _ = urllib.request.urlopen(res)
+        try:
+            # The 'with' statement ensures the connection is closed
+            with _open_url_with_retry(res):
+                pass
+        except urllib.error.HTTPError as e:
+            # This specifically catches HTTP errors like 404, 500, etc.
+            logger.error(f"Validation failed for DOI {doi}. URL <{res}> returned HTTP {e.code}: {e.reason}")
+            # Re-raise the specific HTTPError so the caller can handle it
+            raise e
+        except ConnectionError as e:
+            # This catches the final error from the retry decorator for other issues
+            # (e.g., DNS failure, connection refused).
+            logger.error(f"Could not connect to <{res}> after multiple attempts.")
+            raise e
+            
     return res
-
 
 def resolve_download_file_url(
         doi: str, fi_name: str, validate_uri: bool = True,
@@ -137,61 +218,47 @@ def resolve_download_file_url(
     """
     :meta private:
     Resolve file URI from supported DOI with given filename
-
-    Args:
-        doi (str): DOI string
-        fi_name (str): name of the file to resolve from source
-        validate_uri (bool, optional): Check if URI exists. Defaults to True.
-        sleep429 (int, optional): Sleep in seconds if 429 HTTP code returned
-
-    Raises:
-        NotImplementedError: Unsupported DOI repository
-        HTTPError: HTTP Error Status Code
-        URLError: Failed to reach the server
-
-    Returns:
-        str: file URI
     """
     if "zenodo" in doi.lower():
         zenodo_entry_number = doi.split(".")[2]
         uri = "https://zenodo.org/record/" + zenodo_entry_number + "/files/" + fi_name
 
-        # check if ressource exists, may throw exception
         if validate_uri:
             try:
-                socket.setdefaulttimeout(10)  # seconds
-                _ = urllib.request.urlopen(uri, timeout=10)
-            except TimeoutError:
-                raise RuntimeError(f"Cannot open {uri}. Timeout error.")
+                # Use the decorated helper to check if the URI exists
+                with _open_url_with_retry(uri):
+                    pass
             except urllib.error.HTTPError as hte:
+                # Special handling for 429 after retries have failed
                 if hte.code == 429:
-                    if sleep429/5 > 10:
+                    if sleep429 / 5 > 10:
                         raise TimeoutError(
-                            "Too many iteration of increasing waiting time!")
-                    logger.warning(f"HTTP error returned from URI: {uri}")
-                    logger.warning(f"Site returns 429 code."
-                                   f" Try to sleep {sleep429} seconds and repeat!")
+                            "Too many iterations of increasing waiting time for 429 error!"
+                        )
+                    logger.warning(
+                        f"Site returned 429 (Too Many Requests) for URI: {uri}. "
+                        f"Sleeping {sleep429} seconds before retrying..."
+                    )
                     time.sleep(sleep429)
-                    return resolve_download_file_url(doi, fi_name, validate_uri,
-                                                     sleep429=sleep429+5)
+                    # Recursive call with increased sleep time
+                    return resolve_download_file_url(
+                        doi, fi_name, validate_uri, sleep429=sleep429 + 5
+                    )
                 else:
-                    raise hte
+                    # Other persistent HTTP errors are re-raised
+                    raise
+            except ConnectionError as ce:
+                # Catch the final failure from our decorator for other network issues
+                raise RuntimeError(f"Cannot open {uri}. Failed after multiple retries.") from ce
         return uri
     else:
         raise NotImplementedError(
             "Repository not validated. Please upload the data for example to zenodo.org"
         )
 
-
 def calc_file_sha1_hash(fi: str, step: int = 67108864, one_block: bool = True) -> str:
     """
     Calculates SHA1 hash of given file using hashlib.
-
-    :param fi: (str) path to file
-    :param step: (int, optional) file read bytes step. Defaults to 64MB.
-    :param one_block: (bool, optional) read just a single block. Defaults to True.
-
-    :returns str: sha1 filehash of 40 char length
     """
     sha1_hash = hashlib.sha1()
     n_tot_steps = math.ceil(os.path.getsize(fi) / step)
@@ -200,14 +267,11 @@ def calc_file_sha1_hash(fi: str, step: int = 67108864, one_block: bool = True) -
             block = f.read(step)
             sha1_hash.update(block)
         else:
-            # we don't need tqdm from one-block SHA1
-            with tqdm(total=n_tot_steps) as pbar:
-                # Read and update hash string value in blocks of 4K
+            with tqdm(total=n_tot_steps, desc="Calculating SHA1") as pbar:
                 for byte_block in iter(lambda: f.read(step), b""):
                     sha1_hash.update(byte_block)
                     pbar.update(1)
     return sha1_hash.hexdigest()
-
 
 def create_databank_directories(
         sim: Mapping, 
@@ -217,17 +281,6 @@ def create_databank_directories(
         ) -> str:
     """
     Creates nested output directory structure to save results.
-
-    :param sim: Processed simulation entries.
-    :param sim_hashes: File hashes needed for directory structure.
-    :param out: Output base path (str).
-    :param dry_run_mode: If True, do not create directories, just return the path.
-
-    :returns: Output directory (str).
-
-    :raises NotImplementedError: If the simulation software is unsupported.
-    :raises OSError: If an error occurs while creating the output directory.
-    :raises FileExistsError: If the output directory already exists and is not empty.
     """
     # resolve output dir naming
     if sim["SOFTWARE"] == "gromacs":
@@ -247,13 +300,11 @@ def create_databank_directories(
 
     logger.debug(f"output_dir = {directory_path}")
 
-    # destination directory is not empty
-    if os.path.exists(directory_path) and os.listdir(directory_path) != 0:
+    if os.path.exists(directory_path) and os.listdir(directory_path):
         raise FileExistsError(
             f"Output directory '{directory_path}' is not empty. Delete it if you wish."
         )
 
-    # create directories
     if not dry_run_mode:
         os.makedirs(directory_path, exist_ok=True)
 

--- a/Scripts/DatabankLib/databankio.py
+++ b/Scripts/DatabankLib/databankio.py
@@ -395,6 +395,10 @@ def create_databank_directories(
         )
 
     if not dry_run_mode:
-        os.makedirs(directory_path, exist_ok=True)
+        try:
+            os.makedirs(directory_path, exist_ok=True)
+        except Exception as e:
+            raise RuntimeError(f"Could not create the output directory at {directory_path}: {e}")
+
 
     return directory_path

--- a/Scripts/DatabankLib/databankio.py
+++ b/Scripts/DatabankLib/databankio.py
@@ -58,7 +58,6 @@ def retry_with_exponential_backoff(max_attempts=3, delay_seconds=1):
                     # This block now primarily handles non-HTTP errors or retriable HTTP errors.
                     pass # Fall through to the retry logic below
 
-                # --- Existing retry logic ---
                 attempts += 1
                 if attempts < max_attempts:
                     logger.warning(

--- a/Scripts/DatabankLib/databankio.py
+++ b/Scripts/DatabankLib/databankio.py
@@ -283,25 +283,9 @@ def resolve_download_file_url(
                 # Use the decorated helper to check if the URI exists
                 with _open_url_with_retry(uri):
                     pass
-            except urllib.error.HTTPError as hte:
-                # Special handling for 429 after retries have failed
-                if hte.code == 429:
-                    if sleep429 / 5 > 10:
-                        raise TimeoutError(
-                            "Too many iterations of increasing waiting time for 429 error!"
-                        )
-                    logger.warning(
-                        f"Site returned 429 (Too Many Requests) for URI: {uri}. "
-                        f"Sleeping {sleep429} seconds before retrying..."
-                    )
-                    time.sleep(sleep429)
-                    # Recursive call with increased sleep time
-                    return resolve_download_file_url(
-                        doi, fi_name, validate_uri, sleep429=sleep429 + 5
-                    )
-                else:
-                    # Other persistent HTTP errors are re-raised
-                    raise
+            except urllib.error.HTTPError:
+                # Other persistent HTTP errors are re-raised
+                raise
             except ConnectionError as ce:
                 # Catch the final failure from our decorator for other network issues
                 raise RuntimeError(f"Cannot open {uri}. Failed after multiple retries.") from ce

--- a/Scripts/DatabankLib/databankio.py
+++ b/Scripts/DatabankLib/databankio.py
@@ -276,7 +276,7 @@ def resolve_download_file_url(
     """
     if "zenodo" in doi.lower():
         zenodo_entry_number = doi.split(".")[2]
-        uri = "https://zenodo.org/record/" + zenodo_entry_number + "/files/" + fi_name
+        uri = f"https://zenodo.org/record/{zenodo_entry_number}/files/{fi_name}"
 
         if validate_uri:
             try:

--- a/Scripts/DatabankLib/databankio.py
+++ b/Scripts/DatabankLib/databankio.py
@@ -44,13 +44,13 @@ def retry_with_exponential_backoff(max_attempts=3, delay_seconds=1):
                 # --- New logic to handle non-retriable HTTP client errors ---
                 except urllib.error.HTTPError as e:
                     # Check if the error is a client error (4xx) which is not likely to be resolved by a retry.
-                    if 400 <= e.code < 500:
+                    if 400 <= e.code < 500 and e.code != 429:
                         logger.error(
                             f"Function {func.__name__} failed with non-retriable client error {e.code}: {e.reason}"
                         )
                         raise e  # Re-raise the HTTPError immediately
                     
-                    # For other errors (like 5xx server errors), proceed with retry logic.
+                    # For other errors (like 5xx server errors or 429), proceed with retry logic.
                     logger.warning(f"Caught retriable HTTPError {e.code}. Proceeding with retry...")
                     # Fall through to the generic exception handling below.
                 

--- a/Scripts/DatabankLib/databankio.py
+++ b/Scripts/DatabankLib/databankio.py
@@ -372,18 +372,25 @@ def create_databank_directories(
         RuntimeError: If the target output directory could not be created.
     """
     # resolve output dir naming
-    if sim["SOFTWARE"] == "gromacs":
-        head_dir = sim_hashes.get("TPR")[0][1][0:3]
-        sub_dir1 = sim_hashes.get("TPR")[0][1][3:6]
-        sub_dir2 = sim_hashes.get("TPR")[0][1]
-        sub_dir3 = sim_hashes.get("TRJ")[0][1]
-    elif sim["SOFTWARE"] == "openMM" or sim["SOFTWARE"] == "NAMD":
-        head_dir = sim_hashes.get("TRJ")[0][1][0:3]
-        sub_dir1 = sim_hashes.get("TRJ")[0][1][3:6]
-        sub_dir2 = sim_hashes.get("TRJ")[0][1]
-        sub_dir3 = sim_hashes.get("TRJ")[0][1]
-    else:
-        raise NotImplementedError(f"sim software '{sim['SOFTWARE']}' not supported")
+    software = sim.get("SOFTWARE")
+
+    SOFTWARE_CONFIG = {
+        "gromacs": {"primary": "TPR", "secondary": "TRJ"},
+        "openMM":  {"primary": "TRJ", "secondary": "TRJ"},
+        "NAMD":    {"primary": "TRJ", "secondary": "TRJ"},
+    }
+
+    config = SOFTWARE_CONFIG.get(software)
+    if not config:
+        raise NotImplementedError(f"sim software '{software}' not supported")
+
+    primary_hash = sim_hashes.get(config["primary"])[0][1]
+    secondary_hash = sim_hashes.get(config["secondary"])[0][1]
+
+    head_dir = primary_hash[:3]
+    sub_dir1 = primary_hash[3:6]
+    sub_dir2 = primary_hash
+    sub_dir3 = secondary_hash
 
     directory_path = os.path.join(out, head_dir, sub_dir1, sub_dir2, sub_dir3)
 

--- a/Scripts/DatabankLib/databankio.py
+++ b/Scripts/DatabankLib/databankio.py
@@ -25,8 +25,12 @@ logger = logging.getLogger(__name__)
 MAX_DRYRUN_SIZE = 50 * 1024 * 1024  # 50 MB, max size for dry-run download
 
 def retry_with_exponential_backoff(max_attempts=3, delay_seconds=1):
-    """
-    Decorator that retries a function with exponential backoff for transient network errors.
+    """Decorator that retries a function with exponential backoff.
+
+    Args:
+        max_attempts (int): The maximum number of attempts. Defaults to 3.
+        delay_seconds (int): The initial delay between retries in seconds.
+            The delay doubles after each failed attempt. Defaults to 1.
     """
     def decorator(func):
         @functools.wraps(func)
@@ -78,22 +82,44 @@ def retry_with_exponential_backoff(max_attempts=3, delay_seconds=1):
 
 @retry_with_exponential_backoff(max_attempts=5, delay_seconds=2)
 def _open_url_with_retry(uri: str, timeout: int = 10):
-    """
-    A private helper to open a URL with a timeout and retry logic.
-    Returns the response object.
+    """A private helper to open a URL with a timeout and retry logic.
+
+    Args:
+        uri (str): The URL to open.
+        timeout (int): The timeout for the request in seconds. Defaults to 10.
+
+    Returns:
+        The response object from urllib.request.urlopen.
     """
     return urllib.request.urlopen(uri, timeout=timeout)
 
 @retry_with_exponential_backoff(max_attempts=5, delay_seconds=2)
 def get_file_size_with_retry(uri: str) -> int:
-    """Fetches the size of a file from a URI with retry logic."""
+    """Fetches the size of a file from a URI with retry logic.
+
+    Args:
+        uri (str): The URL of the file.
+
+    Returns:
+        int: The size of the file in bytes, or 0 if the 'Content-Length'
+            header is not present.
+    """
     with _open_url_with_retry(uri) as response:
         content_length = response.getheader('Content-Length')
         return int(content_length) if content_length else 0
 
 @retry_with_exponential_backoff(max_attempts=5, delay_seconds=2)
 def download_with_progress_with_retry(uri: str, dest: str, fi_name: str) -> None:
-    """Downloads a file with a progress bar and retry logic."""
+    """Downloads a file with a progress bar and retry logic.
+
+    Uses tqdm to display a progress bar during the download.
+
+    Args:
+        uri (str): The URL of the file to download.
+        dest (str): The local destination path to save the file.
+        fi_name (str): The name of the file, used for the progress bar
+            description.
+    """
     class RetrieveProgressBar(tqdm):
         def update_retrieve(self, b=1, bsize=1, tsize=None):
             if tsize is not None:
@@ -111,16 +137,28 @@ def download_resource_from_uri(
     uri: str, dest: str, override_if_exists: bool = False,
     dry_run_mode: bool = False
 ) -> int:
-    """
-    Download file resource from uri to given file destination using urllib.
-    
-    :param uri: (str) file URL
-    :param dest: (str) file destination path
-    :param override_if_exists: (bool, optional) Override dest. file if exists. Defaults to False.
-    
-    :raises ConnectionError: An error occurred after multiple download attempts.
-    
-    :return: code (int) 0 - OK, 1 - skipped, 2 - redownloaded
+    """Download file resource from a URI to a local destination.
+
+    Checks if the file already exists and has the same size before downloading.
+    Can also perform a partial "dry-run" download.
+
+    Args:
+        uri (str): The URL of the file resource.
+        dest (str): The local destination path to save the file.
+        override_if_exists (bool): If True, the file will be re-downloaded
+            even if it already exists. Defaults to False.
+        dry_run_mode (bool): If True, only a partial download is performed
+            (up to MAX_DRYRUN_SIZE). Defaults to False.
+
+    Returns:
+        int: A status code indicating the result.
+            0: Download was successful.
+            1: Download was skipped because the file already exists.
+            2: File was re-downloaded due to a size mismatch.
+
+    Raises:
+        ConnectionError: An error occurred after multiple download attempts.
+        OSError: The downloaded file size does not match the expected size.
     """
     fi_name = uri.split("/")[-1]
 
@@ -180,17 +218,20 @@ def download_resource_from_uri(
     return 0
 
 def resolve_doi_url(doi: str, validate_uri: bool = True) -> str:
-    """
-    Returns the full DOI URL and validates that it is a reachable address.
+    """Resolves a DOI to a full URL and validates that it is reachable.
 
-    :param doi: (str) The DOI identifier (e.g., "10.5281/zenodo.1234")
-    :param validate_uri: (bool, optional) If True, checks if the URL is valid. Defaults to True.
+    Args:
+        doi (str): The DOI identifier (e.g., "10.5281/zenodo.1234").
+        validate_uri (bool): If True, checks if the resolved URL is a valid
+            and reachable address. Defaults to True.
 
-    :raises urllib.error.HTTPError: If the DOI resolves to a URL, but the server returns an
-                                    HTTP error code (e.g., 404 Not Found).
-    :raises ConnectionError: If the server cannot be reached after multiple retries.
-    
-    :return: (str) The full, validated DOI link.
+    Returns:
+        str: The full, validated DOI link (e.g., "https://doi.org/...").
+
+    Raises:
+        urllib.error.HTTPError: If the DOI resolves to a URL, but the server
+            returns an HTTP error code (e.g., 404 Not Found).
+        ConnectionError: If the server cannot be reached after multiple retries.
     """
     res = "https://doi.org/" + doi
 
@@ -213,11 +254,25 @@ def resolve_doi_url(doi: str, validate_uri: bool = True) -> str:
     return res
 
 def resolve_download_file_url(
-        doi: str, fi_name: str, validate_uri: bool = True,
-        sleep429=5) -> str:
-    """
-    :meta private:
-    Resolve file URI from supported DOI with given filename
+        doi: str, fi_name: str, validate_uri: bool = True) -> str:
+    """:meta private:
+    Resolves a download file URI from a supported DOI and filename.
+
+    Currently supports Zenodo DOIs.
+
+    Args:
+        doi (str): The DOI identifier for the repository (e.g.,
+            "10.5281/zenodo.1234").
+        fi_name (str): The name of the file within the repository.
+        validate_uri (bool): If True, checks if the resolved URL is a valid
+            and reachable address. Defaults to True.
+
+    Returns:
+        str: The full, direct download URL for the file.
+
+    Raises:
+        RuntimeError: If the URL cannot be opened after multiple retries.
+        NotImplementedError: If the DOI provider is not supported.
     """
     if "zenodo" in doi.lower():
         zenodo_entry_number = doi.split(".")[2]
@@ -257,8 +312,20 @@ def resolve_download_file_url(
         )
 
 def calc_file_sha1_hash(fi: str, step: int = 67108864, one_block: bool = True) -> str:
-    """
-    Calculates SHA1 hash of given file using hashlib.
+    """Calculates the SHA1 hash of a file.
+
+    Reads the file in chunks to handle large files efficiently if specified.
+
+    Args:
+        fi (str): The path to the file.
+        step (int): The chunk size in bytes for reading the file.
+            Defaults to 64MB. Only used if `one_block` is False.
+        one_block (bool): If True, reads the first `step` bytes of the file.
+            If False, reads the entire file in chunks of `step` bytes.
+            Defaults to True.
+
+    Returns:
+        str: The hexadecimal SHA1 hash of the file content.
     """
     sha1_hash = hashlib.sha1()
     n_tot_steps = math.ceil(os.path.getsize(fi) / step)
@@ -279,8 +346,30 @@ def create_databank_directories(
         out: str,
         dry_run_mode: bool = False
         ) -> str:
-    """
-    Creates nested output directory structure to save results.
+    """Creates a nested output directory structure to save simulation results.
+
+    The directory structure is generated based on the hashes of the simulation
+    input files.
+
+    Args:
+        sim (Mapping): A dictionary containing simulation metadata, including
+            the "SOFTWARE" key.
+        sim_hashes (Mapping): A dictionary mapping file types (e.g., "TPR",
+            "TRJ") to their hash information. The structure is expected to be
+            `{'TYPE': [('filename', 'hash')]}`.
+        out (str): The root output directory where the nested structure
+            will be created.
+        dry_run_mode (bool): If True, the directory path is resolved but
+            not created. Defaults to False.
+
+    Returns:
+        str: The full path to the created output directory.
+
+    Raises:
+        FileExistsError: If the target output directory already exists and is
+            not empty.
+        NotImplementedError: If the simulation software is not supported.
+        RuntimeError: If the target output directory could not be created.
     """
     # resolve output dir naming
     if sim["SOFTWARE"] == "gromacs":

--- a/Scripts/DatabankLib/databankio.py
+++ b/Scripts/DatabankLib/databankio.py
@@ -200,7 +200,7 @@ def download_resource_from_uri(
                 out_file.write(chunk)
                 downloaded += len(chunk)
                 if downloaded >= next_report:
-                    print(f"  Downloaded {downloaded // (1024*1024)} MB ...")
+                    logger.info(f"  Downloaded {downloaded // (1024*1024)} MB ...")
                     next_report += 10 * 1024 * 1024
             logger.info(
                 "Dry-run: Finished, downloaded"

--- a/Scripts/DatabankLib/requirements-dev.txt
+++ b/Scripts/DatabankLib/requirements-dev.txt
@@ -12,3 +12,4 @@ flake8
 pep8-naming
 pytest
 pytest-check
+pytest-mock

--- a/Scripts/tests/test_loads.py
+++ b/Scripts/tests/test_loads.py
@@ -6,7 +6,7 @@ NOTE: globally import of DatabankLib is **STRICTLY FORBIDDEN** because it
 """
 
 import os
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 import pytest
 
 # run only without mocking data
@@ -71,6 +71,75 @@ class TestResolveDoiUrl:
         # good DOI works properly
         assert ("https://doi.org/10.5281/zenodo.8435138" ==
                 dio.resolve_doi_url('10.5281/zenodo.8435138', True))
+
+    @staticmethod
+    def _create_mock_success_response(mocker):
+        mock_response = mocker.MagicMock()
+        mock_response.read.return_value = b"mocked content"
+        mock_response.getheader.return_value = "100" # Content-Length
+        mock_response.code = 200
+        mock_response.reason = "OK"
+        return mock_response
+
+    @pytest.mark.parametrize(
+        "name, side_effects_func, expected_exception, expected_call_count",
+        [
+            (
+                "transient URLError succeeds",
+                lambda m: [URLError('err1'), URLError('err2'), TestResolveDoiUrl._create_mock_success_response(m)],
+                None,
+                3,
+            ),
+            (
+                "persistent URLError fails",
+                lambda m: URLError('persistent error'),
+                ConnectionError,
+                5,
+            ),
+            (
+                "non-retriable 403 HTTPError fails immediately",
+                lambda m: HTTPError('url', 403, 'Forbidden', {}, None),
+                HTTPError,
+                1,
+            ),
+            (
+                "retriable 503 HTTPError succeeds",
+                lambda m: [HTTPError('url', 503, 'Service Unavailable', {}, None), HTTPError('url', 503, 'Service Unavailable', {}, None), TestResolveDoiUrl._create_mock_success_response(m)],
+                None,
+                3,
+            ),
+            (
+                "persistent 503 HTTPError fails",
+                lambda m: HTTPError('url', 503, 'Service Unavailable', {}, None),
+                ConnectionError,
+                5,
+            ),
+        ],
+    )
+    def test_retry_logic__resolve_doi_url(
+        self, name, side_effects_func, expected_exception, expected_call_count, mocker
+    ):
+        import DatabankLib.databankio as dio
+
+        mocker.patch('time.sleep', return_value=None)
+
+        side_effects = side_effects_func(mocker)
+
+        mock_urlopen = mocker.patch(
+            'DatabankLib.databankio.urllib.request.urlopen',
+            side_effect=side_effects
+        )
+
+        if expected_exception:
+            with pytest.raises(expected_exception) as excinfo:
+                dio.resolve_doi_url('10.5281/zenodo.8435138', True)
+            if expected_exception == HTTPError:
+                actual_http_error = side_effects[0] if isinstance(side_effects, list) else side_effects
+                assert excinfo.value.code == actual_http_error.code
+        else:
+            dio.resolve_doi_url('10.5281/zenodo.8435138', True)
+
+        assert mock_urlopen.call_count == expected_call_count, f"Test '{name}' failed on call count."
 
     # resolve_download_file_url
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     url=get_variable_from_file('url', init_fpath),
     package_dir={"": "Scripts"},
     package_data={"": ["*.yaml"]},
-    packages=["DatabankLib"],
+    packages=["DatabankLib", "DatabankLib.settings"],
     install_requires=parse_requirements(
         path.join('.', 'Scripts', 'DatabankLib', 'requirements.txt')),
     classifiers=[


### PR DESCRIPTION
closes issue #319 

All the http requests are wrapped with the "retry_with_exponential_backoff" decorator. It will try to complete the request 5 times with increasing intervals before failing. This should prevent many transient errors from the server. Note that for 4XX errors the code quits without retrying