### PR TITLE
Allow option in run_analysis to exit with non zero exit code

### DIFF
--- a/src/DatabankLib/utils.py
+++ b/src/DatabankLib/utils.py
@@ -28,6 +28,11 @@ def run_analysis(
                      (None, None) which means all systems. Can be also (None, -1)
                      which means all new systems, or (0, None) which means all
                      old systems.
+    Environment variables:
+        - ``NML_STRICT_MODE``: if set to ``"true"`` or ``"1"`` (case-insensitive),
+          the function will exit with code ``RCODE_ERROR`` if one or more analyses
+          fail. When unset, empty, or any other value, failed analyses are only
+          logged and execution continues normally.
 
     :return: None
     """
@@ -55,6 +60,11 @@ def run_analysis(
     SKIPPED: {result_dict[RCODE_SKIPPED]}
     ERROR: {result_dict[RCODE_ERROR]}
     """)
-    if os.getenv("NML_STRICT_MODE") and result_dict[RCODE_ERROR] > 0:
-        logger.error("Detected %d failed analyses. Exiting with code %d.", result_dict[RCODE_ERROR], RCODE_ERROR)
+    strict_mode = os.getenv("NML_STRICT_MODE", "").lower() in ("1", "true")
+    if strict_mode and result_dict[RCODE_ERROR] > 0:
+        logger.error(
+            "Detected %d failed analyses. Exiting with code %d.",
+            result_dict[RCODE_ERROR],
+            RCODE_ERROR,
+        )
         sys.exit(RCODE_ERROR)


### PR DESCRIPTION
A quick proposed solution for allowing CI jobs to fail properly when analysis reports errors. Closes #354 

Maybe there are more direct ways to archive the same while touching less code, but a change like this is great for adding new simulations where we don't want to read through logs to check for errors. 

<!-- readthedocs-preview Databank start -->
----
📚 Documentation preview 📚: https://Databank--355.org.readthedocs.build/en/355/

<!-- readthedocs-preview Databank end -->