### PR TITLE
exclude readthedocs from MANIFEST after renaming

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,7 +14,7 @@ exclude .codecov.yml
 exclude .gitignore
 exclude .gitmodules
 exclude .pre-commit-config.yaml
-exclude .readthedocs.yml
+exclude .readthedocs.yaml
 exclude CONTRIBUTING.md
 exclude CONTRIBUTING.rst
 exclude CONTRIBUTION.md


### PR DESCRIPTION
hotfix to repair building. Please someone approve!

<!-- readthedocs-preview fairmd-lipids start -->
----
📚 Documentation preview 📚: https://fairmd-lipids--371.org.readthedocs.build/en/371/

<!-- readthedocs-preview fairmd-lipids end -->