### PR TITLE
Adding list functionality to run_analysis

### DIFF
--- a/src/fairmd/lipids/utils.py
+++ b/src/fairmd/lipids/utils.py
@@ -14,7 +14,7 @@ from fairmd.lipids import RCODE_COMPUTED, RCODE_ERROR, RCODE_SKIPPED
 from fairmd.lipids.core import initialize_databank
 
 
-def run_analysisNEW(method: Callable, logger: Logger, id_range=None, id_list=None) -> None:
+def run_analysis(method: Callable, logger: Logger, id_range=None, id_list=None) -> None:
     """
     Apply analysis ``method`` to the entire databank.
 
@@ -60,7 +60,7 @@ def run_analysisNEW(method: Callable, logger: Logger, id_range=None, id_list=Non
         res = method(system, logger)
         result_dict[res] += 1
 
-    print(f"""
+    logger.info(f"""
     COMPUTED: {result_dict[RCODE_COMPUTED]}
     SKIPPED: {result_dict[RCODE_SKIPPED]}
     ERROR: {result_dict[RCODE_ERROR]}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -417,3 +417,38 @@ def test_GetOP_missing_file_warns(systems, systemid, testmol, result):
         assert resdic[testmol] is result
         # Check a warning was raised containing the molecule name
         assert any(f"{testmol}OrderParameters.json not found" in str(wi.message) for wi in w)
+
+
+def test_run_analysis_interface():
+    from fairmd.lipids import RCODE_COMPUTED, RCODE_ERROR, RCODE_SKIPPED
+    from fairmd.lipids.utils import run_analysis
+
+    # create logger for testing
+    import logging
+    from io import StringIO
+
+    log_stream = StringIO()
+    _logger = logging.getLogger("test_run_analysis")
+    _logger.setLevel(logging.INFO)
+    _logger.addHandler(logging.StreamHandler(log_stream))
+
+    def dummy_method(system, logger):
+        logger.info(f"Dummy method called for system ID {system['ID']}")
+        return RCODE_COMPUTED
+
+    run_analysis(
+        method=dummy_method,
+        logger=_logger,
+        id_range=(None, None),
+    )
+
+    check.is_in("COMPUTED: 5", log_stream.getvalue())
+    check.is_in("SKIPPED: 0", log_stream.getvalue())
+
+    run_analysis(
+        method=dummy_method,
+        logger=_logger,
+        id_list=[86, 281, 243],
+    )
+
+    check.is_in("COMPUTED: 3", log_stream.getvalue())


### PR DESCRIPTION
As discussed in https://github.com/NMRLipids/FAIRMD_lipids/issues/365, I added the ability to run_analysis to handle ID lists. Assumes that list of length 2 means a range still, for length of !=2 runs analysis for the spesific IDs on the inputted list.

<!-- readthedocs-preview fairmd-lipids start -->
----
📚 Documentation preview 📚: https://fairmd-lipids--382.org.readthedocs.build/en/382/

<!-- readthedocs-preview fairmd-lipids end -->