### PR TITLE
Fix the RTD-doc link for PRs

### DIFF
--- a/.github/workflows/readthedocs-link.yml
+++ b/.github/workflows/readthedocs-link.yml
@@ -15,4 +15,5 @@ jobs:
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: fairmd-lipids
+          project-slug: databank
+          single-version: true


### PR DESCRIPTION
Fixes the link added to PR's for Read The Docs.

Uses the current active name on RTD which is `databank` and removes the language part of the URL.

Closes #388 

<!-- readthedocs-preview fairmd-lipids start -->
----
📚 Documentation preview 📚: https://fairmd-lipids--389.org.readthedocs.build/en/389/

<!-- readthedocs-preview fairmd-lipids end -->