### PR TITLE
3 unused API removed

### DIFF
--- a/src/fairmd/lipids/databankLibrary.py
+++ b/src/fairmd/lipids/databankLibrary.py
@@ -9,12 +9,10 @@ import logging
 import math
 import os
 import subprocess
-import sys
 import warnings
 
 import MDAnalysis as mda
 import numpy as np
-from deprecated import deprecated
 
 from fairmd.lipids import FMDL_SIMU_PATH
 from fairmd.lipids.core import System
@@ -187,44 +185,6 @@ def getLipids(system: System, molecules=lipids_set):  # noqa: N802 (API name)
     return lipids
 
 
-def simulation2universal_atomnames(system: System, molname: str, atom: str):
-    """
-    Maps an atomic name from the simulation system to the corresponding universal
-    atomic name based on the provided molecule and atom. This function attempts to
-    retrieve the atomic name using the mapping dictionary or None.
-
-    :param system: The simulation system object
-    :param molname: The name of the molecule
-    :param atom: The specific atom name
-    :return: The universal atomic name or None (if not found)
-    """
-    try:
-        mdict = system.content[molname].mapping_dict
-    except KeyError:
-        sys.stderr.write(f"Molecule '{molname}' was not found in the system!")
-        return None
-    try:
-        m_atom1 = mdict[atom]["ATOMNAME"]
-    except (KeyError, TypeError):
-        sys.stderr.write(
-            f"{atom} was not found from {system['COMPOSITION'][molname]['MAPPING']}!",
-        )
-        return None
-
-    return m_atom1
-
-
-@deprecated(reason="Mapping handling is completely refactored.")
-def loadMappingFile(mapping_file):  # noqa: N802 (API name)
-    """
-    This function is deprecated. Use Molecule.register_mapping() from
-    DatbankLib.settings.molecules instead.
-    """
-    raise NotImplementedError(
-        "This function is deprecated. Use Molecule.register_mapping() instead.",
-    )
-
-
 def getAtoms(system: System, lipid: str):  # noqa: N802 (API name)
     """
     Return system specific atom names of a lipid
@@ -240,36 +200,6 @@ def getAtoms(system: System, lipid: str):  # noqa: N802 (API name)
         atoms = atoms + " " + mdict[key]["ATOMNAME"]
 
     return atoms
-
-
-def getUniversalAtomName(  # noqa: N802 (API name)
-    system: System,
-    atom_name: str,
-    molname: str,
-):
-    """
-    Returns the universal atom name corresponding the simulation specific ``atomName``
-    of a ``lipid`` in a simulation defined by the ``system``.
-
-    :param system: system dictionary
-    :param atom_name: simulation specific atomname
-    :param molname: universal lipid name
-
-    :return: universal atomname (string) or None
-    """
-    try:
-        mdict = system.content[molname].mapping_dict
-    except KeyError:
-        sys.stderr.write(f"Molecule '{molname}' was not found in the system!")
-        return None
-
-    for universal_name in mdict:
-        sim_name = mdict[universal_name]["ATOMNAME"]
-        if sim_name == atom_name:
-            return universal_name
-
-    sys.stderr.write("Atom was not found!\n")
-    return None
 
 
 def calc_angle(atoms, com):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -183,45 +183,6 @@ def test_raises_averageOrderParameters(systems, systemid):
     assert "OrderParameters.json" in str(exc_info.value)
 
 
-@pytest.mark.parametrize(
-    "systemid, lipid, result",
-    [
-        (281, ["POPC/P"], ["M_G3P2_M"]),
-        (566, ["POPC/P31", "CHOL/C1"], ["M_G3P2_M", "M_C1_M"]),
-        (787, ["TOCL/P3", "POPC/P", "POPE/P"], ["M_G13P1_M", "M_G3P2_M", "M_G3P2_M"]),
-        (243, ["DPPC/P8"], ["M_G3P2_M"]),
-        (86, ["POPE/P8"], ["M_G3P2_M"]),
-    ],
-)
-def test_getUniversalAtomName(systems, systemid, lipid, result):
-    from fairmd.lipids.databankLibrary import getUniversalAtomName
-
-    sys0 = systems.loc(systemid)
-    i = 0
-    for i, lipat in enumerate(lipid):
-        lip, atom = tuple(lipat.split("/"))
-        uname = getUniversalAtomName(sys0, atom, lip)
-        check.equal(uname, result[i])
-
-
-# Test fail-behavior of getUniversalAtomName
-
-
-@pytest.mark.parametrize(
-    "systemid, lipat, result",
-    [(243, "DPPC/nonExisting", "Atom was not found"), (243, "nonExisting/P8", "was not found in the system")],
-)
-def test_bad_getUniversalAtomName(systems, systemid, lipat, result, capsys):
-    from fairmd.lipids.databankLibrary import getUniversalAtomName
-
-    sys0 = systems.loc(systemid)
-    lip, atom = tuple(lipat.split("/"))
-    uname = getUniversalAtomName(sys0, atom, lip)
-    output = capsys.readouterr().err.rstrip()
-    assert result in output
-    assert uname is None
-
-
 @pytest.mark.parametrize("systemid, lipid, result", [(243, "DPPC", "44ea5"), (787, "TOCL", "78629")])
 def test_getAtoms(systems, systemid, lipid, result):
     from fairmd.lipids.databankLibrary import getAtoms
@@ -235,57 +196,6 @@ def test_getAtoms(systems, systemid, lipid, result):
     md5_hash.update(atoms.encode("ascii"))
     hx = md5_hash.hexdigest()[:5]
     assert hx == result
-
-
-@pytest.mark.xfail(reason="Completely deprecated function", run=True, raises=NotImplementedError, strict=True)
-@pytest.mark.parametrize("systemid, lipid, result", [(281, ["POPC"], [134])])
-def test_raise_loadMappingFile(systems, systemid, lipid, result):
-    from fairmd.lipids.databankLibrary import loadMappingFile
-
-    sys0 = systems.loc(systemid)
-    i = 0
-    for i, lip in enumerate(lipid):
-        mpf = loadMappingFile(sys0["COMPOSITION"][lip]["MAPPING"])
-        check.equal(len(mpf), result[i])
-
-
-@pytest.mark.parametrize(
-    "systemid, lipid, result",
-    [
-        (281, ["POPC/P"], ["M_G3P2_M"]),
-        (566, ["POPC/P31", "CHOL/C1"], ["M_G3P2_M", "M_C1_M"]),
-        (787, ["TOCL/P3", "POPC/P", "POPE/P"], ["M_G13P1_M", "M_G3P2_M", "M_G3P2_M"]),
-        (243, ["DPPC/P8"], ["M_G3P2_M"]),
-        (86, ["POPE/P8"], ["M_G3P2_M"]),
-    ],
-)
-def test_simulation2universal_atomnames(systems, systemid, lipid, result):
-    from fairmd.lipids.databankLibrary import simulation2universal_atomnames
-
-    sys0 = systems.loc(systemid)
-    i = 0
-    for i, lipat in enumerate(lipid):
-        lip, atom = tuple(lipat.split("/"))
-        sname = simulation2universal_atomnames(sys0, lip, result[i])
-        check.equal(sname, atom)
-
-
-@pytest.mark.parametrize(
-    "systemid, lipat, result",
-    [
-        (243, "DPPC/nonExisting", "was not found from mappingDPPCberger.yaml"),
-        (243, "nonExisting/M_G1_M", "was not found in the system!"),
-    ],
-)
-def test_bad_simulation2universal_atomnames(systems, systemid, lipat, result, capsys):
-    from fairmd.lipids.databankLibrary import simulation2universal_atomnames
-
-    sys0 = systems.loc(systemid)
-    lip, atom = tuple(lipat.split("/"))
-    sname = simulation2universal_atomnames(sys0, lip, atom)
-    output = capsys.readouterr().err.rstrip()
-    assert result in output
-    assert sname is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_recompute_api.py
+++ b/tests/test_recompute_api.py
@@ -115,14 +115,15 @@ def hashFV(x):
 def test_PJangle(systems, systemid, lipid, fvhash):
     from fairmd.lipids.databankLibrary import (
         read_trj_PN_angles,
-        simulation2universal_atomnames,
         system2MDanalysisUniverse,
     )
 
     s = systems.loc(systemid)
     u = system2MDanalysisUniverse(s)
-    a1 = simulation2universal_atomnames(s, lipid, "M_G3P2_M")
-    a2 = simulation2universal_atomnames(s, lipid, "M_G3N6_M")
+    pats = u.select_atoms(s.content[lipid].uan2selection("M_G3P2_M", lipid))
+    nats = u.select_atoms(s.content[lipid].uan2selection("M_G3N6_M", lipid))
+    a1 = pats.atoms.names[0]
+    a2 = nats.atoms.names[0]
 
     a, b, c, d = read_trj_PN_angles(lipid, a1, a2, u)
     # time-molecule arrays


### PR DESCRIPTION
`simulation2universal_atomnames`, `getUniversalAtomname`, and `loadMapping`. `mol->md2uan` and `mol->uan2selection` must be used instead.

<!-- readthedocs-preview databank start -->
----
📚 Documentation preview 📚: https://databank--392.org.readthedocs.build/

<!-- readthedocs-preview databank end -->