### PR TITLE
Align experimental OrderParameters filename usage with BilayerData

### DIFF
--- a/docs/src/contrib/addingExpData.rst
+++ b/docs/src/contrib/addingExpData.rst
@@ -12,12 +12,12 @@ The keys of these dictionaries are summarized in the :ref:`Experiment metadata d
 
 #. Copy this README file data into a appropriate directory named as described above.
 
-#. If you have order parameter data, create a file named ``{lipidname}_Order_Parameters.dat``
+#. If you have order parameter data, create a file named ``{lipidname}_OrderParameters.json``
    where ``{lipidname}`` is the universal name of the lipid from which the data is measured
    from. The first two columns of this file should define the atom pair with universal
    atom names, third column has the experimental order parameter value, and fourth
    column has the experimental error. If the experimental error is not known, set it to 0.02.
-   Store the created ``{lipidname}_Order_Parameters.dat`` file into the appropriate folder
+   Store the created ``{lipidname}_OrderParameters.json`` file into the appropriate folder
    with the ``README.yaml`` file. Create ``json`` version from ``dat`` file by running
 
    .. code-block:: bash

--- a/src/fairmd/lipids/bin/evaluate_quality.py
+++ b/src/fairmd/lipids/bin/evaluate_quality.py
@@ -69,7 +69,7 @@ def evaluate_quality():
                     readme_exp = yaml.load(yaml_file_exp, Loader=yaml.FullLoader)
                     experiment.readme = readme_exp
 
-                exp_op_fpath = os.path.join(exp_fpath, lipid1 + "_Order_Parameters.json")
+                exp_op_fpath = os.path.join(exp_fpath, lipid1 + "_OrderParameters.json")
                 exp_op_data = {}
                 try:
                     with open(exp_op_fpath) as json_file:

--- a/src/fairmd/lipids/bin/match_experiments.py
+++ b/src/fairmd/lipids/bin/match_experiments.py
@@ -161,7 +161,7 @@ def load_experiments(exp_type: str) -> list[Experiment]:
     readme and order parameter files into objects.
     """
     if exp_type == "OrderParameters":
-        data_file = "_Order_Parameters.json"
+        data_file = "_OrderParameters.json"
     elif exp_type == "FormFactors":
         data_file = "_FormFactor.json"
     else:

--- a/src/fairmd/lipids/ipylib/plottings.py
+++ b/src/fairmd/lipids/ipylib/plottings.py
@@ -290,7 +290,7 @@ def plotSimulation(system, lipid: str):  # noqa: N802
 
     op_exp = {}
     for exp_op_folder in list(system["EXPERIMENT"]["ORDERPARAMETER"][lipid].values()):
-        op_path_exp = os.path.join(FMDL_EXP_PATH, "OrderParameters", exp_op_folder, lipid + "_Order_Parameters.json")
+        op_path_exp = os.path.join(FMDL_EXP_PATH, "OrderParameters", exp_op_folder, lipid + "_OrderParameters.json")
         with open(op_path_exp) as json_file:
             op_exp.update(json.load(json_file))
 


### PR DESCRIPTION
FAIRMD_lipids referenced experimental order parameter files using the
*_Order_Parameters.json naming, which no longer matches the experimental
data layout in BilayerData.

This PR updates code paths and documentation to consistently use
*_OrderParameters.json, aligning with the documented convention and the
current BilayerData structure.

Related to NMRLipids/FAIRMD_lipids#417
Related to NMRLipids/BilayerData PR #262