### PR TITLE
Documentation

### DIFF
--- a/docs/src/dbstructure.rst
+++ b/docs/src/dbstructure.rst
@@ -101,10 +101,10 @@ Simulation quality files
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. :file:`XXXX_OrderParameters_quality.json` contains a dictionary with the quality of
-   each C-H bond against experiments, if available, for molecule XXXX. First key is the 
-   DOI for the source of experimental data. Second key gives C-H pair univeral atom names. 
-   Third key gives values for simulation order parameter, its stardard deviation, standard 
-   error of the mean, experimental order parameter, its error, and finally the quality of 
+   each C-H bond against experiments, if available, for molecule XXXX. First key is the
+   DOI for the source of experimental data. Second key gives C-H pair univeral atom names.
+   Third key gives values for simulation order parameter, its stardard deviation, standard
+   error of the mean, experimental order parameter, its error, and finally the quality of
    the order parameter. Quality is the probability for the agreement between simulated and
    experimental values taking into account the error bars.
 
@@ -112,7 +112,7 @@ Simulation quality files
    <https://doi.org/10.1038/s41467-024-45189-z>`_.
 
 2. :file:`XXXX_FragmentQuality.json` contains fragment qualities determined separately
-   for each lipid XXXX in the simulation with experimental data available using Eq. (4) 
+   for each lipid XXXX in the simulation with experimental data available using Eq. (4)
    in the `FAIRMD Lipids manuscript <https://doi.org/10.1038/s41467-024-45189-z>`_.
 
 3. :file:`SYSTEM_quality.json` contains total qualities averaged over different lipids
@@ -124,6 +124,12 @@ Simulation quality files
    <https://doi.org/10.1038/s41467-024-45189-z>`_. Second term is the scaling
    coefficient for experimental intensities (Eq. (6) in the `FAIRMD Lipids manuscript
    <https://doi.org/10.1038/s41467-024-45189-z>`_).
+
+.. toctree::
+   :maxdepth: 1
+
+   ../quality.rst
+
 
 .. _dbstructure_exp:
 

--- a/docs/src/miscsrc/OrderParameter.rst
+++ b/docs/src/miscsrc/OrderParameter.rst
@@ -1,7 +1,7 @@
 OrderParameter module
 =====================
 
-.. automodule:: fairmd.lipids.databankop
+.. automodule:: fairmd.lipids.analib.databankop
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/src/quality.rst
+++ b/docs/src/quality.rst
@@ -1,3 +1,8 @@
+.. _quality
+
+Simulation quality
+==================
+
 Quality evaluation in the FairMD databank
 ----------------------------------------
 
@@ -17,7 +22,7 @@ The qualities for each simulation record are saved in the files described in
 :ref:`simulation-quality-files`.
 
 The simulations contained in the databank can then be ranked based on their qualities.
-This is exemplified in the ranking files provided in `Ranking files`_.
+This is exemplified in the ranking files provided in :ref:`ranking_files`.
 
 
 Quality evaluation of C–H bond order parameters
@@ -38,16 +43,9 @@ The probability for an order parameter from simulation to lie within experimenta
 bars can be estimated as
 
 .. math::
-   :label: probability
 
-   P =
-   f\!\left(
-     \frac{S_\mathrm{CH} - (S_\mathrm{exp} + \Delta S_\mathrm{exp})}{s / \sqrt{n}}
-   \right)
-   -
-   f\!\left(
-     \frac{S_\mathrm{CH} - (S_\mathrm{exp} - \Delta S_\mathrm{exp})}{s / \sqrt{n}}
-   \right),
+   P = f\!\left(\frac{S_\mathrm{CH} - (S_\mathrm{exp} + \Delta S_\mathrm{exp})}{s / \sqrt{n}}\right)
+     - f\!\left(\frac{S_\mathrm{CH} - (S_\mathrm{exp} - \Delta S_\mathrm{exp})}{s / \sqrt{n}}\right)
 
 where :math:`f(t)` is the first-order Student’s *t*-distribution,
 :math:`n` is the number of independent sample points for each C–H bond (the number of
@@ -112,7 +110,7 @@ minima in some experimental data sets due to noise.
 
 First, fluctuations are filtered from the form factor data using a Savitzky–Golay filter
 (window length 30 and polynomial order 1).
-The first minimum at :math:`q > 0.1\,\mathrm{\AA}^{-1}` is then located for both simulation
+The first minimum at :math:`q > 0.1\,\mathrm{Å}^{-1}` is then located for both simulation
 (:math:`FF_\mathrm{min}^\mathrm{sim}`) and experiment
 (:math:`FF_\mathrm{min}^\mathrm{exp}`).
 
@@ -125,9 +123,6 @@ locations:
    =
    \left| FF_\mathrm{min}^\mathrm{sim} - FF_\mathrm{min}^\mathrm{exp} \right| \times 100.
 
-
-.. _Simulation quality files:
-   https://nmrlipids.github.io/FAIRMD_lipids/stable/dbstructure.html#simulation-quality-files
 
 .. _Ranking files:
    https://github.com/NMRLipids/BilayerData/blob/view-new-rankings/Ranking/


### PR DESCRIPTION
Changed filenames for qualities to not contain POPC but XXXX as for the other files introduced in this documentation. Can @comcon1 check if the file descriptions are up to date? I believe you wanted to remove system quality?

<!-- readthedocs-preview databank start -->
----
📚 Documentation preview 📚: https://databank--437.org.readthedocs.build/

<!-- readthedocs-preview databank end -->