### PR TITLE
Fix crash when both tail qualities are missing

### DIFF
--- a/src/fairmd/lipids/api.py
+++ b/src/fairmd/lipids/api.py
@@ -198,7 +198,14 @@ def get_quality(
         with open(spath) as fd:
             qdict = json.load(fd)
         if part == "tails":
-            return float(np.nanmean([qdict.get("sn-1"), qdict.get("sn-2")]))
+            vals = [qdict.get("sn-1"), qdict.get("sn-2")]
+            vals = [v for v in vals if v is not None]
+
+            if not vals:
+                return np.nan
+
+            return float(np.nanmean(vals))
+
         else:
             return float(qdict[part])
     return q


### PR DESCRIPTION
Fixed a TypeError in `get_quality()` when both sn-1 and sn-2 tail qualities are missing
before this resulted in `np.nanmean([None, None])`
Now missing tail values are filtered and np.nan is returned when no tail data exists.

Resolves #442.


<!-- readthedocs-preview databank start -->
----
📚 Documentation preview 📚: https://databank--443.org.readthedocs.build/

<!-- readthedocs-preview databank end -->