### PR TITLE
Fix analyze.py to write apl.json in the new format

### DIFF
--- a/src/fairmd/lipids/analyze.py
+++ b/src/fairmd/lipids/analyze.py
@@ -157,13 +157,13 @@ def computeAPL(  # noqa: N802 (API)
 
         # this calculates the area per lipid as a function of time and stores it
         # in the databank
-        apl = {}
+        apl = []
         nlipids = system.n_lipids
         for _ts in progress(u.trajectory, desc="Scanning the trajectory"):
             if u.trajectory.time >= system["TIMELEFTOUT"] * 1000:
                 dims = u.dimensions
                 apl_frame = dims[0] * dims[1] * 2 / nlipids
-                apl[u.trajectory.time] = apl_frame
+                apl.append([u.trajectory.time, apl_frame])
 
         with open(outfilename, "w") as f:
             json.dump(apl, f, cls=CompactJSONEncoder)


### PR DESCRIPTION
This is a small error. I just forgot when I prepared the previous PR. 

Because of this error, 4 apl.json-s were writtein in the improper format:
I fixed them here https://github.com/NMRLipids/BilayerData/pull/343 (one who approves this, please also approve that)

It is unfortunately visible only on full tests:
```
=========================== short test summary info ============================
XFAIL tests/test_uc.py::test_fail_nonpredownld_localhost - Localhost with non-downloaded files
FAILED tests/test_analyze.py::test_analyze_apl[86] - AssertionError: assert <class 'dict'> is <class 'list'>
 +  where <class 'dict'> = type({'100000.0078125': 61.4804, '100500.0078125': 60.871, '101000.0078125': 62.5063, '101500.0078125': 61.0159, ...})
 +  and   <class 'list'> = type([[100000, 61.4804], [100500, 60.871], [101000, 62.5063], [101500, 61.0159], [102000, 61.748], [102500, 61.3997], ...])
FAILED tests/test_analyze.py::test_analyze_apl[243] - AssertionError: assert <class 'dict'> is <class 'list'>
 +  where <class 'dict'> = type({'100000.0': 62.5221, '101000.0': 64.232, '102000.0': 63.3142, '103000.0': 62.0184, ...})
 +  and   <class 'list'> = type([[60000, 62.3387], [61000, 60.6071], [62000, 60.7738], [63000, 59.056], [64000, 61.4985], [65000, 60.831], ...])
FAILED tests/test_analyze.py::test_analyze_apl[281] - AssertionError: assert <class 'dict'> is <class 'list'>
 +  where <class 'dict'> = type({'0.0': 61.8543, '1000.0': 61.2496, '10000.0': 66.9242, '100000.0': 64.2833, ...})
 +  and   <class 'list'> = type([[0, 61.8543], [500, 61.2787], [1000, 61.2496], [1500, 62.566], [2000, 64.4796], [2500, 64.3007], ...])
FAILED tests/test_analyze.py::test_analyze_apl[566] - AssertionError: assert <class 'dict'> is <class 'list'>
 +  where <class 'dict'> = type({'0.0': 61.3089, '1000.0': 63.0022, '10000.0': 60.7934, '100000.0': 60.0453, ...})
 +  and   <class 'list'> = type([[0, 61.3089], [500, 63.1422], [1000, 63.0022], [1500, 61.6429], [2000, 60.5616], [2500, 60.9219], ...])
FAILED tests/test_analyze.py::test_analyze_apl[787] - AssertionError: assert <class 'dict'> is <class 'list'>
 +  where <class 'dict'> = type({'120000.0': 76.916, '120500.0': 75.8457, '121000.0': 76.0276, '121500.0': 77.166, ...})
 +  and   <class 'list'> = type([[120000, 76.916], [120500, 75.8457], [121000, 76.0276], [121500, 77.166], [122000, 80.3152], [122500, 77.5843], ...])
====== 5 failed, 190 passed, 1 xfailed, 34 warnings in 611.55s (0:10:11) =======
```

<!-- readthedocs-preview databank start -->
----
📚 Documentation preview 📚: https://databank--473.org.readthedocs.build/

<!-- readthedocs-preview databank end -->