### PR TITLE
Rescaling the Form-Factor Quality

### DIFF
--- a/docs/src/quality.rst
+++ b/docs/src/quality.rst
@@ -73,7 +73,7 @@ We define the average qualities for different fragments
 (frag = *sn-1*, *sn-2*, *headgroup*, or *total*, with the last referring to all order
 parameters within a molecule) within each lipid type in a simulation as
 
-NOTE!!! it seems that total value is actually the average of fragemnst!!!
+NOTE!!! it seems that total value is actually the average of fragments!!!
 
 .. math::
 
@@ -138,7 +138,27 @@ position. For the fit function :math:`f(x) = ax^2 - bx + c`, the error of the mi
    \sigma_\mathrm{min} = \frac{1}{4a^2}\mathrm{cov}[a, a] +
    \frac{b^2}{4a^4}\mathrm{cov}[b, b] - \frac{b}{2a^3}\mathrm{cov}[a, b].
 
-Then, the quality is computed using the same equation as for two order parameter values (see above).
+Then, the quality is computed using the product of penalties from distance, confidence,
+and experiment precision.
+
+.. math::
+
+   FF_q &
+   = \exp{\left(
+        -\frac{(FF_\mathrm{min}^\mathrm{sim} - FF_\mathrm{min}^\mathrm{exp})^2}
+              {\sigma_\mathrm{dpos}^2} \right)} +
+     \exp{\left(
+        -\frac{\sigma_\mathrm{sim}^2+\sigma_\mathrm{exp}^2}
+              {4 \sigma_\mathrm{ref}^2}\right)} +
+   \exp{(-w z^2)}, \\
+   z &
+   = \frac{\left|FF_\mathrm{min}^\mathrm{sim} - FF_\mathrm{min}^\mathrm{exp}\right|}
+            {\sqrt{\sigma_\mathrm{sim}^2+\sigma_\mathrm{exp}^2}}
+
+where :math:`\sigma_\mathrm{dpos} = 0.02` (meaningful distance between peak minima),
+:math:`\sigma_\mathrm{ref} = 0.01` (meaningful average peak uncertainty), :math:`w = 0.3`
+-- free parameter that controls the weight to the significance of statistical confidence of peak
+difference.
 
 Previously, the default quality of a form factor was defined as the distance between the minima locations:
 

--- a/docs/src/quality.rst
+++ b/docs/src/quality.rst
@@ -128,8 +128,19 @@ The first minimum at :math:`q > 0.1\,\mathrm{Å}^{-1}` is then located for both 
 (:math:`FF_\mathrm{min}^\mathrm{sim}`) and experiment
 (:math:`FF_\mathrm{min}^\mathrm{exp}`).
 
-The quality of a form factor is defined as the Euclidean distance between the minima
-locations:
+Currently, for both experiment and simulation, we determine minimum positions with an error estimated
+using the uncertainty of the parabolic fit to the minumum. ``scipy.optimize.curve_fit`` is used to fit
+a parabola to the minimum, and the covariance matrix of the fit is used to estimate the error of the minimum
+position. For the fit function :math:`f(x) = ax^2 - bx + c`, the error of the minimum position is estimated as
+
+.. math::
+
+   \sigma_\mathrm{min} = \frac{1}{4a^2}\mathrm{cov}[a, a] +
+   \frac{b^2}{4a^4}\mathrm{cov}[b, b] - \frac{b}{2a^3}\mathrm{cov}[a, b].
+
+Then, the quality is computed using the same equation as for two order parameter values (see above).
+
+Previously, the default quality of a form factor was defined as the distance between the minima locations:
 
 .. math::
 
@@ -141,4 +152,4 @@ If a simulation is linked to multiple form factors, the experimental data that p
 best form factor quality is chosen.
 
 .. _Ranking files:
-   https://github.com/NMRLipids/BilayerData/blob/view-new-rankings/Ranking/
+   https://github.com/NMRLipids/BilayerData/tree/main/Ranking

--- a/src/fairmd/lipids/analib/formfactor.py
+++ b/src/fairmd/lipids/analib/formfactor.py
@@ -59,7 +59,7 @@ def calc_ff_scaling_distance(ffd_exp: np.ndarray, ffd_sim: np.ndarray) -> tuple[
     return [scf, chi]
 
 
-def calc_minpos_with_error(ffdata: np.ndarray) -> (float, float):
+def calc_minpos_with_error(ffdata: np.ndarray, backup_const_error: float = 0.1) -> (float, float):
     """Estimate error of minimum position in form factor data."""
     m1pos = get_mins_from_ffdata(ffdata)[0]
     idx1pos = ffdata[:, 0].searchsorted(m1pos)
@@ -71,7 +71,7 @@ def calc_minpos_with_error(ffdata: np.ndarray) -> (float, float):
         lambda x, a, b, c: a * x**2 + b * x + c,
         ffdata[idxMinusErr:idxPlusErr, 0],
         ffdata[idxMinusErr:idxPlusErr, 1],
-        sigma=ffdata[idxMinusErr:idxPlusErr, 2] if ffdata.shape[1] > 2 else 0.1,
+        sigma=ffdata[idxMinusErr:idxPlusErr, 2] if ffdata.shape[1] > 2 else backup_const_error,
         absolute_sigma=True,
         p0=[1, -2 * m1pos, 0],
     )

--- a/src/fairmd/lipids/analib/formfactor.py
+++ b/src/fairmd/lipids/analib/formfactor.py
@@ -56,3 +56,7 @@ def calc_ff_scaling_distance(ffd_exp: np.ndarray, ffd_sim: np.ndarray) -> tuple[
     chi = np.sqrt(sum1.sum()) / np.sqrt(max_i - min_i - 1)
 
     return [scf, chi]
+
+def estimate_error_of_min(ffdata: np.ndarray) -> float:
+    """Estimate error of minimum position in form factor data."""
+    return 0

--- a/src/fairmd/lipids/analib/formfactor.py
+++ b/src/fairmd/lipids/analib/formfactor.py
@@ -3,12 +3,11 @@
 import numpy as np
 import scipy.interpolate
 import scipy.signal
-from scipy.optimize import curve_fit
 
 
 def get_mins_from_ffdata(ffdata: np.ndarray) -> list[float]:
     """Find the positions of minimums in form factor data."""
-    sg_window_q = 0.03  # Savitsky-Golay window (in Q)
+    sg_window_q = 0.05  # Savitsky-Golay window (in Q)
     delta_q = ffdata[1, 0] - ffdata[0, 0]  # Q step in FF data
     sg_window_n = int(np.ceil(sg_window_q / delta_q))  # S-G window (in num frames)
     try:
@@ -19,7 +18,8 @@ def get_mins_from_ffdata(ffdata: np.ndarray) -> list[float]:
 
     min_q_distance = 0.01  # Min distance btw peaks (in Q)
     mqd_n = int(np.ceil(min_q_distance / delta_q))  # same in num frames
-    peak_ind = scipy.signal.find_peaks(-filtered, distance=mqd_n)
+    peak_prominence = (filtered.max() - filtered.min()) * 0.1
+    peak_ind = scipy.signal.find_peaks(-filtered, distance=mqd_n, prominence=peak_prominence)
     min_peak_q = 0.1
 
     return [ffdata[i, 0] for i in peak_ind[0] if ffdata[i, 0] > min_peak_q]
@@ -77,5 +77,9 @@ def calc_minpos_with_error(ffdata: np.ndarray) -> (float, float):
     )
     a, b, _c = popt
     min_x = -b / 2 / a
-    delta_minx = (-1/2/a)**2*pcov[0, 0] + (b/2/a**2)**2*pcov[1, 1] + 2*(-1/2/a)*(b/2/a**2)*pcov[0, 1]
+    delta_minx = (
+        (-1 / 2 / a) ** 2 * pcov[0, 0]
+        + (b / 2 / a**2) ** 2 * pcov[1, 1]
+        + 2 * (-1 / 2 / a) * (b / 2 / a**2) * pcov[0, 1]
+    )
     return min_x, np.sqrt(delta_minx)

--- a/src/fairmd/lipids/analib/formfactor.py
+++ b/src/fairmd/lipids/analib/formfactor.py
@@ -18,7 +18,7 @@ def get_mins_from_ffdata(ffdata: np.ndarray) -> list[float]:
 
     min_q_distance = 0.01  # Min distance btw peaks (in Q)
     mqd_n = int(np.ceil(min_q_distance / delta_q))  # same in num frames
-    peak_prominence = (filtered.max() - filtered.min()) * 0.1
+    peak_prominence = (filtered.max() - filtered.min()) * 0.02
     peak_ind = scipy.signal.find_peaks(-filtered, distance=mqd_n, prominence=peak_prominence)
     min_peak_q = 0.1
 

--- a/src/fairmd/lipids/analib/formfactor.py
+++ b/src/fairmd/lipids/analib/formfactor.py
@@ -62,7 +62,6 @@ def calc_ff_scaling_distance(ffd_exp: np.ndarray, ffd_sim: np.ndarray) -> tuple[
 def calc_minpos_with_error(ffdata: np.ndarray, backup_const_error: float = 0.1) -> (float, float):
     """Estimate error of minimum position in form factor data."""
     m1pos = get_mins_from_ffdata(ffdata)[0]
-    idx1pos = ffdata[:, 0].searchsorted(m1pos)
     # find max x val where ypts < 0 in the vicinity x0+-maxerr
     maxXerr = 0.03
     idxPlusErr = ffdata[:, 0].searchsorted(m1pos + maxXerr)

--- a/src/fairmd/lipids/analib/formfactor.py
+++ b/src/fairmd/lipids/analib/formfactor.py
@@ -3,6 +3,7 @@
 import numpy as np
 import scipy.interpolate
 import scipy.signal
+from scipy.optimize import curve_fit
 
 
 def get_mins_from_ffdata(ffdata: np.ndarray) -> list[float]:
@@ -57,6 +58,24 @@ def calc_ff_scaling_distance(ffd_exp: np.ndarray, ffd_sim: np.ndarray) -> tuple[
 
     return [scf, chi]
 
-def estimate_error_of_min(ffdata: np.ndarray) -> float:
+
+def calc_minpos_with_error(ffdata: np.ndarray) -> (float, float):
     """Estimate error of minimum position in form factor data."""
-    return 0
+    m1pos = get_mins_from_ffdata(ffdata)[0]
+    idx1pos = ffdata[:, 0].searchsorted(m1pos)
+    # find max x val where ypts < 0 in the vicinity x0+-maxerr
+    maxXerr = 0.03
+    idxPlusErr = ffdata[:, 0].searchsorted(m1pos + maxXerr)
+    idxMinusErr = ffdata[:, 0].searchsorted(m1pos - maxXerr)
+    popt, pcov = scipy.optimize.curve_fit(
+        lambda x, a, b, c: a * x**2 + b * x + c,
+        ffdata[idxMinusErr:idxPlusErr, 0],
+        ffdata[idxMinusErr:idxPlusErr, 1],
+        sigma=ffdata[idxMinusErr:idxPlusErr, 2] if ffdata.shape[1] > 2 else 0.1,
+        absolute_sigma=True,
+        p0=[1, -2 * m1pos, 0],
+    )
+    a, b, _c = popt
+    min_x = -b / 2 / a
+    delta_minx = (-1/2/a)**2*pcov[0, 0] + (b/2/a**2)**2*pcov[1, 1] + 2*(-1/2/a)*(b/2/a**2)*pcov[0, 1]
+    return min_x, np.sqrt(delta_minx)

--- a/src/fairmd/lipids/bin/evaluate_quality.py
+++ b/src/fairmd/lipids/bin/evaluate_quality.py
@@ -9,9 +9,9 @@ In the standard protocol, it should be run *after* :ref:`fmdl_match_experiments 
 
 .. code-block:: console
 
-    fmdl_evaluate_quality [--op-only | --ff-only]
+    fmdl_evaluate_quality [--op-only | --ff-only] [ --idlist=414,536 ]
 
-No arguments means that both OP and FF qualities are evaluated.
+No arguments means that both OP and FF qualities are evaluated for everything.
 """
 
 import argparse
@@ -35,6 +35,7 @@ def _evaluate_ff_qualities(simulations) -> int:
     counter = 0
     ffexps = ExperimentCollection.load_from_data("FFExperiment")
     for simulation in simulations:
+        print("Evaluating Sim#%d:" % simulation["ID"])
         evaluator = qq.FFQualityEvaluator(simulation, ffexps)
         if evaluator.evaluate_one():
             evaluator.save_results()
@@ -42,8 +43,8 @@ def _evaluate_ff_qualities(simulations) -> int:
     return counter
 
 
-def evaluate_quality_impl(*, do_op: bool = True, do_ff: bool = True) -> None:
-    simulations = qq.QualSimulation.load_all_paired()
+def evaluate_quality_impl(id_list: list[int] | None = None, *, do_op: bool = True, do_ff: bool = True) -> None:
+    simulations = qq.QualSimulation.load_all_paired(id_list)
 
     evaluated_op_counter = _evaluate_op_qualities(simulations) if do_op else 0
     evaluated_ff_counter = _evaluate_ff_qualities(simulations) if do_ff else 0
@@ -64,12 +65,18 @@ def evaluate_quality():
         action="store_true",
         help="Evaluate form factors only (skip order parameters)",
     )
+    parser.add_argument(
+        "--idlist",
+        type=lambda s: [int(x) for x in s.split(",")],
+        default=None,
+        help="Comma-separated list of IDs to evaluate (e.g. 1,2,3)",
+    )
     args = parser.parse_args()
     if args.op_only and args.ff_only:
         msg = "Incompatible arguments. Please choose one."
         raise RuntimeError(msg)
-
     evaluate_quality_impl(
+        id_list=args.idlist,
         do_op=not args.ff_only,
         do_ff=not args.op_only,
     )

--- a/src/fairmd/lipids/bin/evaluate_quality.py
+++ b/src/fairmd/lipids/bin/evaluate_quality.py
@@ -9,10 +9,12 @@ In the standard protocol, it should be run *after* :ref:`fmdl_match_experiments 
 
 .. code-block:: console
 
-    fmdl_evaluate_quality
+    fmdl_evaluate_quality [--op-only | --ff-only]
 
-No arguments are needed.
+No arguments means that both OP and FF qualities are evaluated.
 """
+
+import argparse
 
 import fairmd.lipids.quality as qq
 from fairmd.lipids.experiment import ExperimentCollection
@@ -40,14 +42,37 @@ def _evaluate_ff_qualities(simulations) -> int:
     return counter
 
 
-def evaluate_quality():
+def evaluate_quality_impl(*, do_op: bool = True, do_ff: bool = True) -> None:
     simulations = qq.QualSimulation.load_all_paired()
 
-    evaluated_op_counter = _evaluate_op_qualities(simulations)
-    evaluated_ff_counter = _evaluate_ff_qualities(simulations)
+    evaluated_op_counter = _evaluate_op_qualities(simulations) if do_op else 0
+    evaluated_ff_counter = _evaluate_ff_qualities(simulations) if do_ff else 0
 
     print("The number of systems with evaluated order parameters:", evaluated_op_counter)
     print("The number of systems with evaluated form factors:", evaluated_ff_counter)
+
+
+def evaluate_quality():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--op-only",
+        action="store_true",
+        help="Evaluate order parameters only (skip form factors)",
+    )
+    parser.add_argument(
+        "--ff-only",
+        action="store_true",
+        help="Evaluate form factors only (skip order parameters)",
+    )
+    args = parser.parse_args()
+    if args.op_only and args.ff_only:
+        msg = "Incompatible arguments. Please choose one."
+        raise RuntimeError(msg)
+
+    evaluate_quality_impl(
+        do_op=not args.ff_only,
+        do_ff=not args.op_only,
+    )
 
 
 if __name__ == "__main__":

--- a/src/fairmd/lipids/quality.py
+++ b/src/fairmd/lipids/quality.py
@@ -33,12 +33,14 @@ class QualSimulation(System):
             self.ff_data = None
 
     @staticmethod
-    def load_all_paired() -> list["QualSimulation"]:
+    def load_all_paired(id_list: list[int] | None = None) -> list["QualSimulation"]:
         """Load simulations with experimental pairings."""
         systems = initialize_databank()
 
         simulations = []
         for system in systems:
+            if id_list is not None and system["ID"] not in id_list:
+                continue
             experiments = system.get("EXPERIMENT", {})
             if any(experiments.values()):  # if experiments is not empty
                 s = QualSimulation(system)
@@ -363,7 +365,7 @@ class FFQualityEvaluator(QualityEvaluator):
             if best_ep is None or ffq_scf[0] < results_ff[best_ep][0]:
                 best_ep = expid
 
-        print(f"Form factor quality used for experiment data from {best_ep}:")
+        print(f"Form factor quality used for experiment data from {best_ep}")
         self.ff_quality_output = results_ff[best_ep]
 
         return True
@@ -403,5 +405,20 @@ class FFQualityEvaluator(QualityEvaluator):
         """Calculate form factor quality via p-value of the difference between minima."""
         sim_pos, sim_err = ff.calc_minpos_with_error(ffd_sim, 0.5)
         exp_pos, exp_err = ff.calc_minpos_with_error(ffd_exp, 0.05)
-        ffq = cls.prob_2_within_trustinterval(xv=exp_pos, xerr=exp_err, yv=sim_pos, yerr=sim_err)
-        return ffq
+        print(f"Sim: {sim_pos}+-{sim_err}; Exp: {exp_pos}+-{exp_err}")
+
+        z = abs(sim_pos - exp_pos) / np.sqrt(sim_err**2 + exp_err**2)
+        dpos_ref = 0.02  # natural physical scale
+        sigma_ref = 0.01
+        consistency_weight = 0.3
+
+        # Term 1: are the positions close? (penalises large absolute difference)
+        distance_score = np.exp(-((sim_pos - exp_pos) ** 2) / dpos_ref**2)
+
+        # Term 2: are the measurements precise? (penalises large uncertainty)
+        precision_score = np.exp(-(sim_err**2 + exp_err**2) / 4 * sigma_ref**2)
+
+        # Term 3: are they statistically consistent? (penalises large z)
+        consistency_score = np.exp(-consistency_weight * z**2)
+
+        return distance_score * precision_score * consistency_score

--- a/src/fairmd/lipids/quality.py
+++ b/src/fairmd/lipids/quality.py
@@ -346,7 +346,7 @@ class FFQualityEvaluator(QualityEvaluator):
         for expid in self._sim["EXPERIMENT"]["FORMFACTOR"]:
             exp_ff_data = np.array(self._exps.loc(expid).data)
             results_ff[expid] = [
-                self.calc_ff_quality(self._sim.ff_data, exp_ff_data),
+                self.calc_new_ff_quality(self._sim.ff_data, exp_ff_data),
                 ff.calc_ff_scaling_distance(exp_ff_data, self._sim.ff_data)[0],
             ]
 
@@ -393,3 +393,12 @@ class FFQualityEvaluator(QualityEvaluator):
         exp_min = ff.get_mins_from_ffdata(ffd_exp)
 
         return np.abs(sim_min[0] - exp_min[0]) * 100
+
+    @classmethod
+    def calc_new_ff_quality(cls, ffd_sim: np.ndarray, ffd_exp: np.ndarray) -> float:
+        """Calculate form factor quality via p-value of the difference between minima."""
+        sim_pos, sim_err = ff.calc_minpos_with_error(ffd_sim, 0.5)
+        exp_pos, exp_err = ff.calc_minpos_with_error(ffd_exp, 0.05)
+        ffq = cls.prob_2_within_trustinterval(xv=exp_pos, xerr=exp_err, yv=sim_pos, yerr=sim_err)
+        print(sim_pos, sim_err, exp_pos, exp_err, ffq)
+        return ffq

--- a/src/fairmd/lipids/quality.py
+++ b/src/fairmd/lipids/quality.py
@@ -336,8 +336,12 @@ class OPQualityEvaluator(QualityEvaluator):
 class FFQualityEvaluator(QualityEvaluator):
     """Evaluate quality of form factor data."""
 
-    def evaluate_one(self) -> bool:
+    def evaluate_one(self, method: str = "new") -> bool:
         results_ff = {}
+        if method == "new":
+            method_func = self.calc_new_ff_quality
+        elif method == "old":
+            method_func = self.calc_ff_quality
 
         if "FORMFACTOR" not in self._sim.get("EXPERIMENT", {}) or not self._sim["EXPERIMENT"]["FORMFACTOR"]:
             return False
@@ -346,7 +350,7 @@ class FFQualityEvaluator(QualityEvaluator):
         for expid in self._sim["EXPERIMENT"]["FORMFACTOR"]:
             exp_ff_data = np.array(self._exps.loc(expid).data)
             results_ff[expid] = [
-                self.calc_new_ff_quality(self._sim.ff_data, exp_ff_data),
+                method_func(self._sim.ff_data, exp_ff_data),
                 ff.calc_ff_scaling_distance(exp_ff_data, self._sim.ff_data)[0],
             ]
 
@@ -400,5 +404,4 @@ class FFQualityEvaluator(QualityEvaluator):
         sim_pos, sim_err = ff.calc_minpos_with_error(ffd_sim, 0.5)
         exp_pos, exp_err = ff.calc_minpos_with_error(ffd_exp, 0.05)
         ffq = cls.prob_2_within_trustinterval(xv=exp_pos, xerr=exp_err, yv=sim_pos, yerr=sim_err)
-        print(sim_pos, sim_err, exp_pos, exp_err, ffq)
         return ffq

--- a/tests/test_formfactor.py
+++ b/tests/test_formfactor.py
@@ -33,24 +33,31 @@ def test_get_mins_from_ffdata():
 
 
 def test_estimate_error_of_min():
-    from fairmd.lipids.analib.formfactor import estimate_error_of_min
+    from fairmd.lipids.analib.formfactor import calc_minpos_with_error, get_mins_from_ffdata
 
     # synthetic data
     synt_data = np.zeros((1000, 3))
     synt_data[:, 0] = np.linspace(0, 1, 1000)
     synt_data[:, 1] = np.abs(np.sin(synt_data[:, 0] * 8))
+    synt_data[:, 2] = 0.1
     # Case 0: no error
+    pos_noerr, err_noerr = calc_minpos_with_error(synt_data[:, :2])
+    # this algorithm gives slightly different value of min. But it must be close
+    check.almost_equal(
+        pos_noerr,
+        get_mins_from_ffdata(synt_data[:, :2])[0],
+        abs=5e-4,
+        msg="Minimum precise position is far from the legacy algo",
+    )
     # no error is handled as constant error 0.1
-    err_noerr = estimate_error_of_min(synt_data[:, :2])
-    err_err01 = estimate_error_of_min(synt_data)
+    pos_err01, err_err01 = calc_minpos_with_error(synt_data)
     check.almost_equal(
         err_noerr,
         err_err01,
         abs=1e-3,
-        msg="Error of minimum with no error is not estimated correctly",
+        msg="Error of minimum with no error is not estimated as err=0.1 [const]",
     )
     # Case 1: constant error
-    synt_data[:, 2] = 0.1
     # sin(8x) = 0
     # 8x = pi*n => x = pi*n/8
     #
@@ -62,7 +69,7 @@ def test_estimate_error_of_min():
     #
     # x = +-arcsin(0.1)/8 + pi*n/8; so error should be arcsin(0.1)/8
     #
-    err_comp = estimate_error_of_min(synt_data)
+    pos_comp, err_comp = calc_minpos_with_error(synt_data)
     check.almost_equal(
         err_comp,
         np.arcsin(0.1) / 8,

--- a/tests/test_formfactor.py
+++ b/tests/test_formfactor.py
@@ -57,22 +57,32 @@ def test_estimate_error_of_min():
         abs=1e-3,
         msg="Error of minimum with no error is not estimated as err=0.1 [const]",
     )
-    # Case 1: constant error
-    # sin(8x) = 0
-    # 8x = pi*n => x = pi*n/8
-    #
-    # Error must be estimated as following: we down the curve by the value of error and find intersections
-    # with x axis. The error is the mean distance between the minimum and these intersections. In this
-    # case, the intersections are defined by the equation:
-    #
-    # |sin(8x)|-0.1 = 0 =>> |sin(8x)| = 0.1 =>> sin(8x) = 0.1 or sin(8x) = -0.1, i.e.,
-    #
-    # x = +-arcsin(0.1)/8 + pi*n/8; so error should be arcsin(0.1)/8
-    #
+    # Case 1: 2 constant errors
     pos_comp, err_comp = calc_minpos_with_error(synt_data)
-    check.almost_equal(
+    synt_data[:, 2] = 0.2
+    pos_berr, err_berr = calc_minpos_with_error(synt_data)
+    check.less(
         err_comp,
-        np.arcsin(0.1) / 8,
+        err_berr,
+        msg="Error of minimum with constant error 0.2 must be > than with err 0.1",
+    )
+    check.almost_equal(
+        pos_comp,
+        pos_berr,
+        abs=1e-5,
+        msg="Minimum position with constant error 0.2 must be close to minimum position with constant error 0.1",
+    )
+    # Case 2: noise
+    synt_data[:, 1] += 0.05 * np.random.rand(1000) - 0.025
+    pos_noised, err_noised = calc_minpos_with_error(synt_data)
+    check.less(
+        err_comp,
+        err_noised,
+        msg="Error of minimum with noise is not greater than error of minimum with constant error",
+    )
+    check.almost_equal(
+        pos_comp,
+        pos_noised,
         abs=1e-3,
-        msg="Error of minimum with constant error is not estimated correctly",
+        msg="Minimum position with and w/o noise should be similar",
     )

--- a/tests/test_formfactor.py
+++ b/tests/test_formfactor.py
@@ -30,3 +30,42 @@ def test_get_mins_from_ffdata():
     p = get_mins_from_ffdata(synt_data)
     check.almost_equal(p[0], np.pi / 8, abs=1e-3)
     check.almost_equal(p[1], np.pi / 4, abs=1e-3)
+
+
+def test_estimate_error_of_min():
+    from fairmd.lipids.analib.formfactor import estimate_error_of_min
+
+    # synthetic data
+    synt_data = np.zeros((1000, 3))
+    synt_data[:, 0] = np.linspace(0, 1, 1000)
+    synt_data[:, 1] = np.abs(np.sin(synt_data[:, 0] * 8))
+    # Case 0: no error
+    # no error is handled as constant error 0.1
+    err_noerr = estimate_error_of_min(synt_data[:, :2])
+    err_err01 = estimate_error_of_min(synt_data)
+    check.almost_equal(
+        err_noerr,
+        err_err01,
+        abs=1e-3,
+        msg="Error of minimum with no error is not estimated correctly",
+    )
+    # Case 1: constant error
+    synt_data[:, 2] = 0.1
+    # sin(8x) = 0
+    # 8x = pi*n => x = pi*n/8
+    #
+    # Error must be estimated as following: we down the curve by the value of error and find intersections
+    # with x axis. The error is the mean distance between the minimum and these intersections. In this
+    # case, the intersections are defined by the equation:
+    #
+    # |sin(8x)|-0.1 = 0 =>> |sin(8x)| = 0.1 =>> sin(8x) = 0.1 or sin(8x) = -0.1, i.e.,
+    #
+    # x = +-arcsin(0.1)/8 + pi*n/8; so error should be arcsin(0.1)/8
+    #
+    err_comp = estimate_error_of_min(synt_data)
+    check.almost_equal(
+        err_comp,
+        np.arcsin(0.1) / 8,
+        abs=1e-3,
+        msg="Error of minimum with constant error is not estimated correctly",
+    )


### PR DESCRIPTION
FormFactor will be rescaled in this PR as we already discussed between collaborators. We will use the same probability estimate as for order parameters; it requires us to define the error of the position of the first minimum. 

After it is done, we can issue a combined quality measure (*will NOT BE DONE in this PR*).

- [x] add testing function for `estimate_error_of_min`
- [x] implement `estimate_error_of_min`
- [x] add documentation piece for the updated FF quality measure
- [x] plug new quality evaluator to the `fmdl_evaluate_quality`

As a small useful bonus, `fmdl_evaluate_quality` now supports `--ff-only` and `--op-only`. Default behavior (used in CI pipelines) was not changed.