### PR TITLE
OP dataset generator (for use in Kaggle Dataset publishing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ cover/
 .vscode/
 
 # development
+developer/*.h5
 AddData-dev.ipynb
 test.py
 

--- a/developer/gen-op-dataset.py
+++ b/developer/gen-op-dataset.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import pandas as pd
+from rdkit import Chem
+from rdkit.Chem import rdMolDescriptors
+from unidecode import unidecode
+
+from fairmd.lipids.experiment import ExperimentCollection, OPExperiment
+
+H5_MASTER = "exp-op-dataset.h5"
+
+
+def store_to_hdf5(df: pd.DataFrame, e: OPExperiment, lipid_name: str):
+    _mcontent = e.membrane_composition(basis="molar")
+    mcontent = {"name": [], "inchikey": [], "fraction": []}
+    for lname, frac in _mcontent.items():
+        k = lname
+        ik = e.lipids[lname].metadata["bioschema_properties"]["inChIKey"]
+        mcontent["name"] += [k]
+        mcontent["inchikey"] += [ik]
+        mcontent["fraction"] += [frac]
+    hydration = e.get_hydration()
+    scontent = e.solution_composition(basis="molar")
+    temperature = e["TEMPERATURE"]
+    inchikey = e.lipids[lipid_name].metadata["bioschema_properties"]["inChIKey"]
+    smiles = e.lipids[lipid_name].metadata["bioschema_properties"]["smiles"]
+    # store all vars and df to the HDF5 table
+    group = "E" + unidecode(e.exp_id).replace("-", "_").replace("/", "_").replace(".", "") + "__" + lipid_name
+
+    with pd.HDFStore(H5_MASTER, "a") as store:
+        # DataFrame table
+        store.put(f"{group}/op_values", df, format="table", data_columns=True)
+        # Metadata attributes
+        op_storer = store.get_storer(f"{group}/op_values")
+        op_storer.attrs["inchikey"] = inchikey
+        op_storer.attrs["smiles"] = smiles
+
+        # Metadata attributes
+        store.put(f"{group}/sample_table", pd.DataFrame(mcontent), format="table", data_columns=True)
+        sample_storer = store.get_storer(f"{group}/op_values")
+        sample_storer.attrs["temperature"] = temperature
+        sample_storer.attrs["hydration"] = hydration
+        sample_storer.attrs["solution"] = ", ".join([f"{k:<25} {v * 100:>6.1f}%" for k, v in sorted(scontent.items())])
+
+
+def by_c_uname(opdict: dict, uname: str) -> dict:
+    """Return only OP vals of named heavy atoms. Sorted by val."""
+    res = []
+    for k, v in opdict.items():
+        if k.split()[0] == uname:
+            res.append(v)
+    return sorted(res, key=lambda x: x[0])
+
+
+def main() -> None:
+    print("Generating OP datasets.")
+    ee = ExperimentCollection.load_from_data("OPExperiment")
+    for e in ee:
+        print(e)
+        for lname, opdict in e.data.items():
+            mol = e.lipids[lname]
+            smiles = mol.metadata["bioschema_properties"]["smiles"]
+            rdmol = Chem.MolFromSmiles("CCO")  # Ethanol
+            n_heavy_atoms = rdMolDescriptors.CalcNumHeavyAtoms(rdmol)
+            print(smiles)
+            smi2uname = {}
+            for uname, aprops in mol.mapping_dict.items():
+                if "SMILEIDX" in aprops:
+                    smid = int(aprops["SMILEIDX"])
+                    smi2uname[smid] = uname
+            if not smi2uname:
+                # NO SMILEIDX. Cannot store.
+                continue
+            smi2uname = dict(sorted(smi2uname.items()))
+            df = pd.DataFrame(
+                {
+                    "id": np.full(len(opdict), -1, dtype=np.int64),  # int64, init NaN
+                    "val": np.full(len(opdict), np.nan),
+                    "err": np.full(len(opdict), np.nan),
+                }
+            )
+            cur_row = 0
+            for id_, uname in smi2uname.items():
+                for opdict_row in by_c_uname(opdict, uname):
+                    if cur_row >= len(df):
+                        break
+                    df.at[cur_row, "id"] = id_
+                    df.at[cur_row, "val"] = opdict_row[0]
+                    df.at[cur_row, "err"] = 0.02 if len(opdict_row) == 1 else opdict_row[1]
+                    cur_row += 1
+            # now, we are ready to store to HDF5
+            store_to_hdf5(df, e, lname)
+
+
+if __name__ == "__main__":
+    main()

--- a/developer/gen-op-dataset.py
+++ b/developer/gen-op-dataset.py
@@ -2,8 +2,6 @@
 
 import numpy as np
 import pandas as pd
-from rdkit import Chem
-from rdkit.Chem import rdMolDescriptors
 from unidecode import unidecode
 
 from fairmd.lipids.experiment import ExperimentCollection, OPExperiment
@@ -11,86 +9,121 @@ from fairmd.lipids.experiment import ExperimentCollection, OPExperiment
 H5_MASTER = "exp-op-dataset.h5"
 
 
-def store_to_hdf5(df: pd.DataFrame, e: OPExperiment, lipid_name: str):
-    _mcontent = e.membrane_composition(basis="molar")
-    mcontent = {"name": [], "inchikey": [], "fraction": []}
-    for lname, frac in _mcontent.items():
-        k = lname
-        ik = e.lipids[lname].metadata["bioschema_properties"]["inChIKey"]
-        mcontent["name"] += [k]
-        mcontent["inchikey"] += [ik]
-        mcontent["fraction"] += [frac]
-    hydration = e.get_hydration()
-    scontent = e.solution_composition(basis="molar")
-    temperature = e["TEMPERATURE"]
-    inchikey = e.lipids[lipid_name].metadata["bioschema_properties"]["inChIKey"]
-    smiles = e.lipids[lipid_name].metadata["bioschema_properties"]["smiles"]
-    # store all vars and df to the HDF5 table
-    group = "E" + unidecode(e.exp_id).replace("-", "_").replace("/", "_").replace(".", "") + "__" + lipid_name
-
-    with pd.HDFStore(H5_MASTER, "a") as store:
-        # DataFrame table
-        store.put(f"{group}/op_values", df, format="table", data_columns=True)
-        # Metadata attributes
-        op_storer = store.get_storer(f"{group}/op_values")
-        op_storer.attrs["inchikey"] = inchikey
-        op_storer.attrs["smiles"] = smiles
-
-        # Metadata attributes
-        store.put(f"{group}/sample_table", pd.DataFrame(mcontent), format="table", data_columns=True)
-        sample_storer = store.get_storer(f"{group}/op_values")
-        sample_storer.attrs["temperature"] = temperature
-        sample_storer.attrs["hydration"] = hydration
-        sample_storer.attrs["solution"] = ", ".join([f"{k:<25} {v * 100:>6.1f}%" for k, v in sorted(scontent.items())])
+class OPDataError(Exception):
+    """Our specific exception"""
 
 
-def by_c_uname(opdict: dict, uname: str) -> dict:
-    """Return only OP vals of named heavy atoms. Sorted by val."""
-    res = []
-    for k, v in opdict.items():
-        if k.split()[0] == uname:
-            res.append(v)
-    return sorted(res, key=lambda x: x[0])
+class OPDataStorer:
+    def store_to_hdf5(self):
+        _mcontent = self._e.membrane_composition(basis="molar")
+        mcontent = {"name": [], "inchikey": [], "fraction": []}
+        for lname, frac in _mcontent.items():
+            k = lname
+            ik = self._e.lipids[lname].metadata["bioschema_properties"]["inChIKey"]
+            mcontent["name"] += [k]
+            mcontent["inchikey"] += [ik]
+            mcontent["fraction"] += [frac]
+        hydration = self._e.get_hydration()
+        scontent = self._e.solution_composition(basis="molar")
+        temperature = self._e["TEMPERATURE"]
+        inchikey = self._e.lipids[self._lname].metadata["bioschema_properties"]["inChIKey"]
+        smiles = self._e.lipids[self._lname].metadata["bioschema_properties"]["smiles"]
+        nmr_method = self._e.metadata.get("NMR", {}).get("METHOD", False)
+        # store all vars and df to the HDF5 table
+        group = "E"
+        group += (
+            unidecode(self._e.exp_id)
+            .replace("-", "_")  # prefer variable-like strs
+            .replace("/", "_")
+            .replace(".", "")
+        )
+        group += "__" + self._lname
+        with pd.HDFStore(H5_MASTER, "a") as store:
+            # DataFrame table
+            store.put(f"{group}/op_values", self._df, format="table", data_columns=True)
+            store.put(f"{group}/sample_table", pd.DataFrame(mcontent), format="table", data_columns=True)
+            # Metadata attributes
+            upd_attr = {
+                "inchikey": inchikey,
+                "smiles": smiles,
+                "fmdl_expid": self._e.exp_id,
+            }
+            if nmr_method:
+                upd_attr["nmr_method"] = nmr_method
+            op_storer = store.get_storer(f"{group}/op_values")
+            for k, v in upd_attr.items():
+                op_storer.attrs[k] = v
+
+            # Metadata attributes
+            upd_attr = {
+                "temperature": temperature,
+                "hydration": hydration,
+                "solution": ", ".join([f"{k:<25} {v * 100:>6.1f}%" for k, v in sorted(scontent.items())]),
+            }
+            sample_storer = store.get_storer(f"{group}/sample_table")
+            for k, v in upd_attr.items():
+                sample_storer.attrs[k] = v
+
+    @staticmethod
+    def by_c_uname(opdict: dict, uname: str) -> dict:
+        """Return only OP vals of named heavy atoms. Sorted by val."""
+        res = []
+        for k, v in opdict.items():
+            if k.split()[0] == uname:
+                res.append(v)
+        return sorted(res, key=lambda x: x[0])
+
+    def __init__(self, e: OPExperiment, lname: str):
+        self._e = e
+        self._lname = lname
+
+    def prepare_dataframe(self):
+        mol = self._e.lipids[self._lname]
+        opdict = self._e.data[self._lname]
+        smiles = mol.metadata["bioschema_properties"]["smiles"]
+        print(smiles)
+        smi2uname = {}
+        for uname, aprops in mol.mapping_dict.items():
+            if "SMILEIDX" in aprops:
+                smid = int(aprops["SMILEIDX"])
+                smi2uname[smid] = uname
+        if not smi2uname:
+            # NO SMILEIDX. Cannot store.
+            msg = f"Experiment {self._e.exp_id} // {self._lname} cannot be stored: we don't have SMILEIDX."
+            raise OPDataError(msg)
+        smi2uname = dict(sorted(smi2uname.items()))
+        df = pd.DataFrame(
+            {
+                "id": np.full(len(opdict), -1, dtype=np.int64),  # int64, init NaN
+                "val": np.full(len(opdict), np.nan),
+                "err": np.full(len(opdict), np.nan),
+            }
+        )
+        cur_row = 0
+        for id_, uname in smi2uname.items():
+            for opdict_row in self.by_c_uname(opdict, uname):
+                if cur_row >= len(df):
+                    break
+                df.at[cur_row, "id"] = id_
+                df.at[cur_row, "val"] = opdict_row[0]
+                df.at[cur_row, "err"] = 0.02 if len(opdict_row) == 1 else opdict_row[1]
+                cur_row += 1
+        self._df = df
 
 
 def main() -> None:
     print("Generating OP datasets.")
-    ee = ExperimentCollection.load_from_data("OPExperiment")
-    for e in ee:
-        print(e)
-        for lname, opdict in e.data.items():
-            mol = e.lipids[lname]
-            smiles = mol.metadata["bioschema_properties"]["smiles"]
-            rdmol = Chem.MolFromSmiles("CCO")  # Ethanol
-            n_heavy_atoms = rdMolDescriptors.CalcNumHeavyAtoms(rdmol)
-            print(smiles)
-            smi2uname = {}
-            for uname, aprops in mol.mapping_dict.items():
-                if "SMILEIDX" in aprops:
-                    smid = int(aprops["SMILEIDX"])
-                    smi2uname[smid] = uname
-            if not smi2uname:
-                # NO SMILEIDX. Cannot store.
+    exps = ExperimentCollection.load_from_data("OPExperiment")
+    for exp in exps:
+        print(exp)
+        for lname in exp.data:
+            ods = OPDataStorer(exp, lname)
+            try:
+                ods.prepare_dataframe()
+            except OPDataError as e:
+                print("ERROR: ", e)
                 continue
-            smi2uname = dict(sorted(smi2uname.items()))
-            df = pd.DataFrame(
-                {
-                    "id": np.full(len(opdict), -1, dtype=np.int64),  # int64, init NaN
-                    "val": np.full(len(opdict), np.nan),
-                    "err": np.full(len(opdict), np.nan),
-                }
-            )
-            cur_row = 0
-            for id_, uname in smi2uname.items():
-                for opdict_row in by_c_uname(opdict, uname):
-                    if cur_row >= len(df):
-                        break
-                    df.at[cur_row, "id"] = id_
-                    df.at[cur_row, "val"] = opdict_row[0]
-                    df.at[cur_row, "err"] = 0.02 if len(opdict_row) == 1 else opdict_row[1]
-                    cur_row += 1
-            # now, we are ready to store to HDF5
-            store_to_hdf5(df, e, lname)
+            ods.store_to_hdf5()
 
 
 if __name__ == "__main__":

--- a/developer/gen-op-dataset.py
+++ b/developer/gen-op-dataset.py
@@ -1,20 +1,82 @@
 #!/usr/bin/env python3
 
+from abc import ABC, abstractmethod
+
 import numpy as np
 import pandas as pd
 from unidecode import unidecode
 
+from fairmd.lipids.api import get_OP
+from fairmd.lipids.core import System, initialize_databank
 from fairmd.lipids.experiment import ExperimentCollection, OPExperiment
-
-H5_MASTER = "exp-op-dataset.h5"
 
 
 class OPDataError(Exception):
     """Our specific exception"""
 
 
-class OPDataStorer:
-    def store_to_hdf5(self):
+class OPDataStorer(ABC):
+    @abstractmethod
+    def store_to_hdf5(self, hdf_fname: str):
+        """Store the record"""
+
+    @abstractmethod
+    def prepare_dataframe(self):
+        """Prepare dataframe for storing"""
+
+    @property
+    @abstractmethod
+    def ass_id(self):
+        """Get id of assoc object"""
+
+    def _prepare_df_common(self, mol, opdict, err_extractor):
+        """Common code for dataframe conditioning for storage"""
+        smiles = mol.metadata["bioschema_properties"]["smiles"]
+        print(smiles)
+        smi2uname = {}
+        for uname, aprops in mol.mapping_dict.items():
+            if "SMILEIDX" in aprops:
+                smid = int(aprops["SMILEIDX"])
+                smi2uname[smid] = uname
+        if not smi2uname:
+            # NO SMILEIDX. Cannot store.
+            msg = f"Instance {self.ass_id} // {self._lname} cannot be stored: we don't have SMILEIDX."
+            raise OPDataError(msg)
+        smi2uname = dict(sorted(smi2uname.items()))
+        df = pd.DataFrame(
+            {
+                "id": np.full(len(opdict), -1, dtype=np.int64),  # int64, init NaN
+                "val": np.full(len(opdict), np.nan),
+                "err": np.full(len(opdict), np.nan),
+            }
+        )
+        cur_row = 0
+        for id_, uname in smi2uname.items():
+            for opdict_row in OPDataStorer.by_c_uname(opdict, uname):
+                if cur_row >= len(df):
+                    break
+                df.at[cur_row, "id"] = id_
+                df.at[cur_row, "val"] = opdict_row[0]
+                df.at[cur_row, "err"] = err_extractor(opdict_row)
+                cur_row += 1
+        self._df = df
+
+    @staticmethod
+    def by_c_uname(opdict: dict, uname: str) -> dict:
+        """Return only OP vals of named heavy atoms. Sorted by val."""
+        res = []
+        for k, v in opdict.items():
+            if k.split()[0] == uname:
+                res.append(v)
+        return sorted(res, key=lambda x: x[0])
+
+
+class ExpOPDataStorer(OPDataStorer):
+    @property
+    def ass_id(self):
+        return self._e.exp_id
+
+    def store_to_hdf5(self, hdf_fname: str):
         _mcontent = self._e.membrane_composition(basis="molar")
         mcontent = {"name": [], "inchikey": [], "fraction": []}
         for lname, frac in _mcontent.items():
@@ -38,11 +100,12 @@ class OPDataStorer:
             .replace(".", "")
         )
         group += "__" + self._lname
-        with pd.HDFStore(H5_MASTER, "a") as store:
+        with pd.HDFStore(hdf_fname, "a") as store:
             # DataFrame table
             store.put(f"{group}/op_values", self._df, format="table", data_columns=True)
             store.put(f"{group}/sample_table", pd.DataFrame(mcontent), format="table", data_columns=True)
-            # Metadata attributes
+            # Metadata attributes - I
+            op_storer = store.get_storer(f"{group}/op_values")
             upd_attr = {
                 "inchikey": inchikey,
                 "smiles": smiles,
@@ -50,28 +113,17 @@ class OPDataStorer:
             }
             if nmr_method:
                 upd_attr["nmr_method"] = nmr_method
-            op_storer = store.get_storer(f"{group}/op_values")
             for k, v in upd_attr.items():
                 op_storer.attrs[k] = v
-
-            # Metadata attributes
+            # -//- II
+            sample_storer = store.get_storer(f"{group}/sample_table")
             upd_attr = {
                 "temperature": temperature,
                 "hydration": hydration,
                 "solution": ", ".join([f"{k:<25} {v * 100:>6.1f}%" for k, v in sorted(scontent.items())]),
             }
-            sample_storer = store.get_storer(f"{group}/sample_table")
             for k, v in upd_attr.items():
                 sample_storer.attrs[k] = v
-
-    @staticmethod
-    def by_c_uname(opdict: dict, uname: str) -> dict:
-        """Return only OP vals of named heavy atoms. Sorted by val."""
-        res = []
-        for k, v in opdict.items():
-            if k.split()[0] == uname:
-                res.append(v)
-        return sorted(res, key=lambda x: x[0])
 
     def __init__(self, e: OPExperiment, lname: str):
         self._e = e
@@ -80,51 +132,113 @@ class OPDataStorer:
     def prepare_dataframe(self):
         mol = self._e.lipids[self._lname]
         opdict = self._e.data[self._lname]
-        smiles = mol.metadata["bioschema_properties"]["smiles"]
-        print(smiles)
-        smi2uname = {}
-        for uname, aprops in mol.mapping_dict.items():
-            if "SMILEIDX" in aprops:
-                smid = int(aprops["SMILEIDX"])
-                smi2uname[smid] = uname
-        if not smi2uname:
-            # NO SMILEIDX. Cannot store.
-            msg = f"Experiment {self._e.exp_id} // {self._lname} cannot be stored: we don't have SMILEIDX."
-            raise OPDataError(msg)
-        smi2uname = dict(sorted(smi2uname.items()))
-        df = pd.DataFrame(
-            {
-                "id": np.full(len(opdict), -1, dtype=np.int64),  # int64, init NaN
-                "val": np.full(len(opdict), np.nan),
-                "err": np.full(len(opdict), np.nan),
+        self._prepare_df_common(mol, opdict, err_extractor=lambda x: 0.02 if len(x) == 1 else x[1])
+
+
+class SimOPDataStorer(OPDataStorer):
+    @property
+    def ass_id(self):
+        return self._s["ID"]
+
+    def prepare_dataframe(self):
+        mol = self._s.lipids[self._lname]
+        opdict = get_OP(self._s)[self._lname]
+        self._prepare_df_common(mol, opdict, err_extractor=lambda x: x[2])
+
+    def store_to_hdf5(self, hdf_fname: str):
+        _mcontent = self._s["COMPOSITION"]
+        mcontent = {"name": [], "inchikey": [], "number": [], "asymmetry": []}
+        for lname, lip in self._s.lipids.items():
+            ik = lip.metadata["bioschema_properties"]["inChIKey"]
+            cnt = _mcontent[lname]["COUNT"]
+            if isinstance(cnt, int):
+                asm = np.nan
+                cnt = [cnt / 2, cnt / 2]
+            else:
+                asm = cnt[0] / sum(cnt)
+            mcontent["name"] += [lname]
+            mcontent["inchikey"] += [ik]
+            mcontent["number"] += [sum(cnt) / 2]
+            mcontent["asymmetry"] += [asm]
+        hydration = self._s.get_hydration()
+        scontent = self._s.solution_composition(basis="molar")
+        temperature = self._s["TEMPERATURE"]
+        inchikey = self._s.lipids[self._lname].metadata["bioschema_properties"]["inChIKey"]
+        smiles = self._s.lipids[self._lname].metadata["bioschema_properties"]["smiles"]
+        ff_name = self._s.readme.get("FF", False)
+        # store all vars and df to the HDF5 table
+        group = f"SIM_{self._s['ID']}__{self._lname}"
+        with pd.HDFStore(hdf_fname, "a") as store:
+            # DataFrame table
+            store.put(f"{group}/op_values", self._df, format="table", data_columns=True)
+            store.put(f"{group}/simulation_table", pd.DataFrame(mcontent), format="table", data_columns=True)
+            # Metadata attributes - I
+            op_storer = store.get_storer(f"{group}/op_values")
+            upd_attr = {
+                "inchikey": inchikey,
+                "smiles": smiles,
+                "fmdl_simid": self._s["ID"],
             }
-        )
-        cur_row = 0
-        for id_, uname in smi2uname.items():
-            for opdict_row in self.by_c_uname(opdict, uname):
-                if cur_row >= len(df):
-                    break
-                df.at[cur_row, "id"] = id_
-                df.at[cur_row, "val"] = opdict_row[0]
-                df.at[cur_row, "err"] = 0.02 if len(opdict_row) == 1 else opdict_row[1]
-                cur_row += 1
-        self._df = df
+            for k, v in upd_attr.items():
+                op_storer.attrs[k] = v
+            # -//- II
+            sample_storer = store.get_storer(f"{group}/simulation_table")
+            upd_attr = {
+                "temperature": temperature,
+                "hydration": hydration,
+                "solution": ", ".join([f"{k:<25} {v * 100:>6.1f}%" for k, v in sorted(scontent.items())]),
+            }
+            if ff_name:
+                upd_attr["ff_name"] = ff_name
+            for k, v in upd_attr.items():
+                sample_storer.attrs[k] = v
+
+    def __init__(self, sim: System, lname: str):
+        self._s = sim
+        self._lname = lname
 
 
-def main() -> None:
-    print("Generating OP datasets.")
+H5_EXP_MASTER = "exp-op-dataset.h5"
+
+
+def main_exps() -> None:
+    print("Generating OP datasets from experiments.")
     exps = ExperimentCollection.load_from_data("OPExperiment")
     for exp in exps:
         print(exp)
         for lname in exp.data:
-            ods = OPDataStorer(exp, lname)
+            ods = ExpOPDataStorer(exp, lname)
             try:
                 ods.prepare_dataframe()
             except OPDataError as e:
                 print("ERROR: ", e)
                 continue
-            ods.store_to_hdf5()
+            ods.store_to_hdf5(H5_EXP_MASTER)
+
+
+H5_SIMS_MASTER = "sims-op-dataset.h5"
+
+
+def main_sims() -> None:
+    print("Generating OP dataset from simulations.")
+    sims = initialize_databank()
+    for sim in sims:
+        print(sim)
+        opdata = get_OP(sim)
+        if opdata is None:
+            continue
+        for lname in opdata:
+            if opdata[lname] is None:
+                continue
+            ods = SimOPDataStorer(sim, lname)
+            try:
+                ods.prepare_dataframe()
+            except OPDataError as e:
+                print("ERROR: ", e)
+                continue
+            ods.store_to_hdf5(H5_SIMS_MASTER)
 
 
 if __name__ == "__main__":
-    main()
+    main_exps()
+    main_sims()

--- a/developer/gen-op-dataset.py
+++ b/developer/gen-op-dataset.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from abc import ABC, abstractmethod
+import argparse
 
 import numpy as np
 import pandas as pd
@@ -240,5 +241,12 @@ def main_sims() -> None:
 
 
 if __name__ == "__main__":
-    main_exps()
-    main_sims()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exps", action="store_true", help="Run experiments")
+    parser.add_argument("--sims", action="store_true", help="Run simulations")
+    args = parser.parse_args()
+
+    if args.exps:
+        main_exps()
+    if args.sims:
+        main_sims()

--- a/developer/gen-op-dataset.py
+++ b/developer/gen-op-dataset.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from abc import ABC, abstractmethod
 import argparse
+from abc import ABC, abstractmethod
 
 import numpy as np
 import pandas as pd
@@ -10,6 +10,7 @@ from unidecode import unidecode
 from fairmd.lipids.api import get_OP
 from fairmd.lipids.core import System, initialize_databank
 from fairmd.lipids.experiment import ExperimentCollection, OPExperiment
+from fairmd.lipids.molecules import Molecule
 
 
 class OPDataError(Exception):
@@ -17,23 +18,23 @@ class OPDataError(Exception):
 
 
 class OPDataStorer(ABC):
+    """Abstract class for OP data storage"""
+
     @abstractmethod
-    def store_to_hdf5(self, hdf_fname: str):
+    def store_to_hdf5(self, hdf_fname: str) -> None:
         """Store the record"""
 
     @abstractmethod
-    def prepare_dataframe(self):
+    def prepare_dataframe(self) -> None:
         """Prepare dataframe for storing"""
 
     @property
     @abstractmethod
-    def ass_id(self):
+    def ass_id(self) -> str:
         """Get id of assoc object"""
 
-    def _prepare_df_common(self, mol, opdict, err_extractor):
-        """Common code for dataframe conditioning for storage"""
-        smiles = mol.metadata["bioschema_properties"]["smiles"]
-        print(smiles)
+    def _prepare_df_common(self, mol: Molecule, opdict: dict, err_extractor: callable) -> None:
+        """Condition the dataframe for storage"""
         smi2uname = {}
         for uname, aprops in mol.mapping_dict.items():
             if "SMILEIDX" in aprops:
@@ -44,21 +45,11 @@ class OPDataStorer(ABC):
             msg = f"Instance {self.ass_id} // {self._lname} cannot be stored: we don't have SMILEIDX."
             raise OPDataError(msg)
         smi2uname = dict(sorted(smi2uname.items()))
-        df = pd.DataFrame(
-            {
-                "id": np.full(len(opdict), -1, dtype=np.int64),  # int64, init NaN
-                "val": np.full(len(opdict), np.nan),
-                "err": np.full(len(opdict), np.nan),
-            }
-        )
+        df = pd.DataFrame(columns=["id", "val", "err"])
         cur_row = 0
         for id_, uname in smi2uname.items():
             for opdict_row in OPDataStorer.by_c_uname(opdict, uname):
-                if cur_row >= len(df):
-                    break
-                df.at[cur_row, "id"] = id_
-                df.at[cur_row, "val"] = opdict_row[0]
-                df.at[cur_row, "err"] = err_extractor(opdict_row)
+                df.loc[cur_row] = [id_, opdict_row[0], err_extractor(opdict_row)]
                 cur_row += 1
         self._df = df
 
@@ -73,11 +64,13 @@ class OPDataStorer(ABC):
 
 
 class ExpOPDataStorer(OPDataStorer):
+    """OP data storer for experiments"""
+
     @property
-    def ass_id(self):
+    def ass_id(self) -> str:
         return self._e.exp_id
 
-    def store_to_hdf5(self, hdf_fname: str):
+    def store_to_hdf5(self, hdf_fname: str) -> None:
         _mcontent = self._e.membrane_composition(basis="molar")
         mcontent = {"name": [], "inchikey": [], "fraction": []}
         for lname, frac in _mcontent.items():
@@ -126,11 +119,13 @@ class ExpOPDataStorer(OPDataStorer):
             for k, v in upd_attr.items():
                 sample_storer.attrs[k] = v
 
-    def __init__(self, e: OPExperiment, lname: str):
+    def __init__(self, e: OPExperiment, lname: str) -> None:
+        """Initialize with experiment object and lipid name"""
         self._e = e
         self._lname = lname
 
-    def prepare_dataframe(self):
+    def prepare_dataframe(self) -> None:
+        """Call dataframe preparation"""
         mol = self._e.lipids[self._lname]
         opdict = self._e.data[self._lname]
         self._prepare_df_common(mol, opdict, err_extractor=lambda x: 0.02 if len(x) == 1 else x[1])

--- a/developer/gen-op-dataset.py
+++ b/developer/gen-op-dataset.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from unidecode import unidecode
 
+from fairmd.lipids._base import SampleComposition
 from fairmd.lipids.api import get_OP
 from fairmd.lipids.core import System, initialize_databank
 from fairmd.lipids.experiment import ExperimentCollection, OPExperiment
@@ -24,10 +25,6 @@ class OPDataStorer(ABC):
     """Abstract class for OP data storage"""
 
     @abstractmethod
-    def store_to_hdf5(self, hdf_fname: str) -> None:
-        """Store the record"""
-
-    @abstractmethod
     def prepare_dataframe(self) -> None:
         """Prepare dataframe for storing"""
 
@@ -35,6 +32,11 @@ class OPDataStorer(ABC):
     @abstractmethod
     def ass_id(self) -> str:
         """Get id of assoc object"""
+
+    @property
+    @abstractmethod
+    def sample(self) -> SampleComposition:
+        """Return sample instance"""
 
     def _prepare_df_common(self, mol: Molecule, opdict: dict, err_extractor: callable) -> None:
         """Condition the dataframe for storage"""
@@ -65,6 +67,58 @@ class OPDataStorer(ABC):
                 res.append(v)
         return sorted(res, key=lambda x: x[0])
 
+    def get_mcontent(self) -> dict:
+        """Generate membrane content dictionary"""
+        _mcontent = self.sample.membrane_composition(basis="molar")
+        rdict = {"name": [], "inchikey": [], "fraction": []}
+        for lname, frac in _mcontent.items():
+            k = lname
+            ik = self.sample.lipids[lname].metadata["bioschema_properties"]["inChIKey"]
+            rdict["name"] += [k]
+            rdict["inchikey"] += [ik]
+            rdict["fraction"] += [frac]
+        return rdict
+
+    def get_DF_attrs(self) -> tuple[dict, dict]:
+        """Genererate attributes for OP and Composition dataframes"""
+        inchikey = self.sample.lipids[self._lname].metadata["bioschema_properties"]["inChIKey"]
+        smiles = self.sample.lipids[self._lname].metadata["bioschema_properties"]["smiles"]
+        opt_attr = {
+            "inchikey": inchikey,
+            "smiles": smiles,
+        }
+        hydration = self.sample.get_hydration()
+        scontent = self.sample.solution_composition(basis="molar")
+        smp_attr = {
+            "hydration": hydration,
+            "solution": ", ".join([f"{k:<25} {v * 100:>6.1f}%" for k, v in sorted(scontent.items())]),
+        }
+        return opt_attr, smp_attr
+
+    @abstractmethod
+    def get_H5_gname(self) -> str:
+        """Generate name for the record in the H5 table"""
+
+    def store_to_hdf5(self, hdf_fname: str) -> None:
+        mcontent = self.get_mcontent()
+        opt_attr, smp_attr = self.get_DF_attrs()
+        # store all vars and df to the HDF5 table
+        group = self.get_H5_gname()
+        with pd.HDFStore(hdf_fname, "a") as store:
+            # DataFrame table
+            store.put(f"{group}/op_values", self._df, format="table", data_columns=True)
+            opdf = pd.DataFrame(mcontent)
+            print(opdf)
+            store.put(f"{group}/sample_table", opdf, format="table", data_columns=True)
+            # Metadata attributes - I
+            op_storer = store.get_storer(f"{group}/op_values")
+            for k, v in opt_attr.items():
+                op_storer.attrs[k] = v
+            # -//- II
+            sample_storer = store.get_storer(f"{group}/sample_table")
+            for k, v in smp_attr.items():
+                sample_storer.attrs[k] = v
+
 
 class ExpOPDataStorer(OPDataStorer):
     """OP data storer for experiments"""
@@ -76,53 +130,28 @@ class ExpOPDataStorer(OPDataStorer):
     def ass_id(self) -> str:
         return self._e.exp_id
 
-    def store_to_hdf5(self, hdf_fname: str) -> None:
-        _mcontent = self._e.membrane_composition(basis="molar")
-        mcontent = {"name": [], "inchikey": [], "fraction": []}
-        for lname, frac in _mcontent.items():
-            k = lname
-            ik = self._e.lipids[lname].metadata["bioschema_properties"]["inChIKey"]
-            mcontent["name"] += [k]
-            mcontent["inchikey"] += [ik]
-            mcontent["fraction"] += [frac]
-        hydration = self._e.get_hydration()
-        scontent = self._e.solution_composition(basis="molar")
-        temperature = self._e["TEMPERATURE"]
-        inchikey = self._e.lipids[self._lname].metadata["bioschema_properties"]["inChIKey"]
-        smiles = self._e.lipids[self._lname].metadata["bioschema_properties"]["smiles"]
-        nmr_method = self._e.metadata.get("NMR", {}).get("METHOD", False)
-        # store all vars and df to the HDF5 table
+    @property
+    def sample(self) -> SampleComposition:
+        return self._e
+
+    def get_H5_gname(self) -> str:
         group = "E"
         group += re.sub(r"[^A-Za-z0-9_]", "_", unidecode(self._e.exp_id))
         group += "__" + self._lname
-        with pd.HDFStore(hdf_fname, "a") as store:
-            # DataFrame table
-            store.put(f"{group}/op_values", self._df, format="table", data_columns=True)
-            store.put(f"{group}/sample_table", pd.DataFrame(mcontent), format="table", data_columns=True)
-            # Metadata attributes - I
-            op_storer = store.get_storer(f"{group}/op_values")
-            upd_attr = {
-                "inchikey": inchikey,
-                "smiles": smiles,
-                "fmdl_expid": self._e.exp_id,
-            }
-            if nmr_method:
-                upd_attr["nmr_method"] = nmr_method
-            for k, v in upd_attr.items():
-                op_storer.attrs[k] = v
-            # -//- II
-            sample_storer = store.get_storer(f"{group}/sample_table")
-            upd_attr = {
-                "temperature": temperature,
-                "hydration": hydration,
-                "solution": ", ".join([f"{k:<25} {v * 100:>6.1f}%" for k, v in sorted(scontent.items())]),
-            }
-            for k, v in upd_attr.items():
-                sample_storer.attrs[k] = v
+        return group
+
+    def get_DF_attrs(self) -> tuple[dict, dict]:
+        opt_attr, smp_attr = super().get_DF_attrs()
+        opt_attr ["fmdl_expid"] = self._e.exp_id
+        nmr_method = self._e.metadata.get("NMR", {}).get("METHOD", False)
+        if nmr_method:
+            opt_attr["nmr_method"] = nmr_method
+        smp_attr["temperature"] = self._e["TEMPERATURE"]
+        return opt_attr, smp_attr
 
     def __init__(self, e: OPExperiment, lname: str) -> None:
         """Initialize with experiment object and lipid name"""
-        self._e = e
+        self._e: OPExperiment = e
         self._lname = lname
 
     def prepare_dataframe(self) -> None:
@@ -144,60 +173,44 @@ class SimOPDataStorer(OPDataStorer):
     def ass_id(self):
         return self._s["ID"]
 
+    @property
+    def sample(self) -> SampleComposition:
+        return self._s
+
     def prepare_dataframe(self):
         mol = self._s.lipids[self._lname]
         opdict = get_OP(self._s)[self._lname]
         self._prepare_df_common(mol, opdict, err_extractor=lambda x: x[2])
 
-    def store_to_hdf5(self, hdf_fname: str):
-        _mcontent = self._s["COMPOSITION"]
-        mcontent = {"name": [], "inchikey": [], "number": [], "asymmetry": []}
-        for lname, lip in self._s.lipids.items():
-            ik = lip.metadata["bioschema_properties"]["inChIKey"]
-            cnt = _mcontent[lname]["COUNT"]
+    def get_H5_gname(self) -> str:
+        return f"SIM_{self._s['ID']}__{self._lname}"
+
+    def get_mcontent(self):
+        retdic = super().get_mcontent()
+        retdic["number"] = [0] * len(retdic["name"])
+        retdic["asymmetry"] = [0] * len(retdic["name"])
+        _simcomp = self._s["COMPOSITION"]
+        for i, lname in enumerate(retdic["name"]):
+            cnt = _simcomp[lname]["COUNT"]
             if isinstance(cnt, int):
                 asm = np.nan
                 cnt = [cnt / 2, cnt / 2]
             else:
                 asm = cnt[0] / sum(cnt)
-            mcontent["name"] += [lname]
-            mcontent["inchikey"] += [ik]
-            mcontent["number"] += [sum(cnt) / 2]
-            mcontent["asymmetry"] += [asm]
-        hydration = self._s.get_hydration()
-        scontent = self._s.solution_composition(basis="molar")
-        temperature = self._s["TEMPERATURE"]
-        inchikey = self._s.lipids[self._lname].metadata["bioschema_properties"]["inChIKey"]
-        smiles = self._s.lipids[self._lname].metadata["bioschema_properties"]["smiles"]
-        ff_name = self._s.readme.get("FF", False)
-        # store all vars and df to the HDF5 table
-        group = f"SIM_{self._s['ID']}__{self._lname}"
-        with pd.HDFStore(hdf_fname, "a") as store:
-            # DataFrame table
-            store.put(f"{group}/op_values", self._df, format="table", data_columns=True)
-            store.put(f"{group}/simulation_table", pd.DataFrame(mcontent), format="table", data_columns=True)
-            # Metadata attributes - I
-            op_storer = store.get_storer(f"{group}/op_values")
-            upd_attr = {
-                "inchikey": inchikey,
-                "smiles": smiles,
-                "fmdl_simid": self._s["ID"],
-            }
-            for k, v in upd_attr.items():
-                op_storer.attrs[k] = v
-            # -//- II
-            sample_storer = store.get_storer(f"{group}/simulation_table")
-            upd_attr = {
-                "temperature": temperature,
-                "hydration": hydration,
-                "solution": ", ".join([f"{k:<25} {v * 100:>6.1f}%" for k, v in sorted(scontent.items())]),
-            }
-            if ff_name:
-                upd_attr["ff_name"] = ff_name
-            for k, v in upd_attr.items():
-                sample_storer.attrs[k] = v
+            retdic["number"][i] = sum(cnt) / 2
+            retdic["asymmetry"][i] = asm
+        return retdic
 
-    def __init__(self, sim: System, lname: str):
+    def get_DF_attrs(self) -> tuple[dict, dict]:
+        opt_attr, smp_attr = super().get_DF_attrs()
+        opt_attr["fmdl_simid"] = self._s["ID"]
+        smp_attr["temperature"] =  self._s["TEMPERATURE"]
+        ff_name = self._s.readme.get("FF", False)
+        if ff_name:
+            smp_attr["ff_name"] = ff_name
+        return opt_attr, smp_attr
+
+    def __init__(self, sim: System, lname: str) -> None:
         self._s = sim
         self._lname = lname
 

--- a/developer/gen-op-dataset.py
+++ b/developer/gen-op-dataset.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import re
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -87,12 +88,7 @@ class ExpOPDataStorer(OPDataStorer):
         nmr_method = self._e.metadata.get("NMR", {}).get("METHOD", False)
         # store all vars and df to the HDF5 table
         group = "E"
-        group += (
-            unidecode(self._e.exp_id)
-            .replace("-", "_")  # prefer variable-like strs
-            .replace("/", "_")
-            .replace(".", "")
-        )
+        group += re.sub(r"[^A-Za-z0-9_]", "_", unidecode(self._e.exp_id))
         group += "__" + self._lname
         with pd.HDFStore(hdf_fname, "a") as store:
             # DataFrame table
@@ -128,7 +124,11 @@ class ExpOPDataStorer(OPDataStorer):
         """Call dataframe preparation"""
         mol = self._e.lipids[self._lname]
         opdict = self._e.data[self._lname]
-        self._prepare_df_common(mol, opdict, err_extractor=lambda x: 0.02 if len(x) == 1 else x[1])
+        self._prepare_df_common(
+            mol,
+            opdict,
+            err_extractor=lambda x: OPExperiment.DEFAULT_ERROR if len(x) == 1 else x[1],
+        )
 
 
 class SimOPDataStorer(OPDataStorer):

--- a/developer/gen-op-dataset.py
+++ b/developer/gen-op-dataset.py
@@ -68,6 +68,9 @@ class OPDataStorer(ABC):
 class ExpOPDataStorer(OPDataStorer):
     """OP data storer for experiments"""
 
+    DEFAULT_EXP_HDFNAME = "exp-op-dataset.h5"
+    """Default filename for the experimental dataset"""
+
     @property
     def ass_id(self) -> str:
         return self._e.exp_id
@@ -133,6 +136,9 @@ class ExpOPDataStorer(OPDataStorer):
 
 
 class SimOPDataStorer(OPDataStorer):
+    DEFAULT_SIMS_HDFNAME = "sims-op-dataset.h5"
+    """Default Dataset Filename"""
+
     @property
     def ass_id(self):
         return self._s["ID"]
@@ -195,9 +201,6 @@ class SimOPDataStorer(OPDataStorer):
         self._lname = lname
 
 
-H5_EXP_MASTER = "exp-op-dataset.h5"
-
-
 def main_exps() -> None:
     print("Generating OP datasets from experiments.")
     exps = ExperimentCollection.load_from_data("OPExperiment")
@@ -210,10 +213,7 @@ def main_exps() -> None:
             except OPDataError as e:
                 print("ERROR: ", e)
                 continue
-            ods.store_to_hdf5(H5_EXP_MASTER)
-
-
-H5_SIMS_MASTER = "sims-op-dataset.h5"
+            ods.store_to_hdf5(ExpOPDataStorer.DEFAULT_EXP_HDFNAME)
 
 
 def main_sims() -> None:
@@ -233,7 +233,7 @@ def main_sims() -> None:
             except OPDataError as e:
                 print("ERROR: ", e)
                 continue
-            ods.store_to_hdf5(H5_SIMS_MASTER)
+            ods.store_to_hdf5(SimOPDataStorer.DEFAULT_SIMS_HDFNAME)
 
 
 if __name__ == "__main__":

--- a/developer/gen-op-dataset.py
+++ b/developer/gen-op-dataset.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import logging
 import re
 import sys
 from abc import ABC, abstractmethod
@@ -201,39 +202,52 @@ class SimOPDataStorer(OPDataStorer):
         self._lname = lname
 
 
-def main_exps() -> None:
-    print("Generating OP datasets from experiments.")
+def main_exps(log: logging.Logger) -> tuple[int, int]:
+    """Generate dataset for experiments"""
+    stat_ok, stat_fail = 0, 0
+    log.info("\n\nGenerating OP datasets from experiments.")
     exps = ExperimentCollection.load_from_data("OPExperiment")
     for exp in exps:
-        print(exp)
         for lname in exp.data:
+            log.info("%s // %s", str(exp), lname)
             ods = ExpOPDataStorer(exp, lname)
             try:
                 ods.prepare_dataframe()
             except OPDataError as e:
-                print("ERROR: ", e)
+                log.error("[from .prepare_dataframe] %s", str(e))  # noqa: TRY400
+                stat_fail += 1
                 continue
+            else:
+                stat_ok += 1
             ods.store_to_hdf5(ExpOPDataStorer.DEFAULT_EXP_HDFNAME)
+            log.info("..stored!")
+    return stat_ok, stat_fail
 
 
-def main_sims() -> None:
-    print("Generating OP dataset from simulations.")
+def main_sims(log: logging.Logger) -> tuple[int, int]:
+    """Generate dataset from simulations"""
+    stat_ok, stat_fail = 0, 0
+    log.info("\n\nGenerating OP dataset from simulations.")
     sims = initialize_databank()
     for sim in sims:
-        print(sim)
         opdata = get_OP(sim)
-        if opdata is None:
-            continue
         for lname in opdata:
-            if opdata[lname] is None:
+            if opdata is None or opdata[lname] is None:
+                stat_fail += 1
                 continue
+            log.info("%s // %s", str(sim), lname)
             ods = SimOPDataStorer(sim, lname)
             try:
                 ods.prepare_dataframe()
             except OPDataError as e:
-                print("ERROR: ", e)
+                log.error("[from .prepare_dataframe] %s", str(e))  # noqa: TRY400
+                stat_fail += 1
                 continue
+            else:
+                stat_ok += 1
             ods.store_to_hdf5(SimOPDataStorer.DEFAULT_SIMS_HDFNAME)
+            log.info("..stored!")
+    return stat_ok, stat_fail
 
 
 if __name__ == "__main__":
@@ -250,11 +264,23 @@ Two DataFrames are stored for each Sim/Exp-lipid pair:
     parser.add_argument("--sims", action="store_true", help="Generate DS from simulations")
     args = parser.parse_args()
 
-    if args.exps:
-        main_exps()
-    if args.sims:
-        main_sims()
-
     if not args.exps and not args.sims:
         parser.print_usage()
         sys.exit(1)
+
+    lg = logging.getLogger("cli")
+    lg.setLevel(logging.INFO)
+    h_stderr = logging.StreamHandler(sys.stderr)
+    h_stderr.setLevel(logging.INFO)
+    lg.addHandler(h_stderr)
+
+    if args.exps:
+        e_ok, e_fail = main_exps(lg)
+    if args.sims:
+        s_ok, s_fail = main_sims(lg)
+
+    lg.info("=======   STATISTICS   ========")
+    if args.exps:
+        lg.info(f"Stored experiment-lipid pairs: {e_ok} // failed: {e_fail}")
+    if args.sims:
+        lg.info(f"Stored simulation-lipid pairs: {s_ok} // failed: {s_fail}")

--- a/developer/gen-op-dataset.py
+++ b/developer/gen-op-dataset.py
@@ -2,6 +2,7 @@
 
 import argparse
 import re
+import sys
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -236,12 +237,24 @@ def main_sims() -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--exps", action="store_true", help="Run experiments")
-    parser.add_argument("--sims", action="store_true", help="Run simulations")
+    parser = argparse.ArgumentParser(
+        prog="OP Dataset Generator",
+        description="""
+CI helper script for delivering dataset for Kaggle in HDF5 format.
+Two DataFrames are stored for each Sim/Exp-lipid pair:
+1. SMILES-aligned values for each atom of the molecule
+2. Composition table of membrane part of the system""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--exps", action="store_true", help="Generate DS from experiments")
+    parser.add_argument("--sims", action="store_true", help="Generate DS from simulations")
     args = parser.parse_args()
 
     if args.exps:
         main_exps()
     if args.sims:
         main_sims()
+
+    if not args.exps and not args.sims:
+        parser.print_usage()
+        sys.exit(1)

--- a/src/fairmd/lipids/experiment.py
+++ b/src/fairmd/lipids/experiment.py
@@ -194,6 +194,9 @@ class OPExperiment(Experiment):
     :meth:`verify_data` checks that all atom unique names in the data correspond to known atoms in the lipid mapping.
     """
 
+    DEFAULT_ERROR = 0.02
+    """Default error value to use when it is not provided"""
+
     @property
     def data(self) -> dict:
         if self._data is None:

--- a/src/fairmd/lipids/quality.py
+++ b/src/fairmd/lipids/quality.py
@@ -18,7 +18,7 @@ from fairmd.lipids import FMDL_SIMU_PATH
 from fairmd.lipids.api import get_FF, get_OP
 from fairmd.lipids.auxiliary import CompactJSONEncoder, mollib
 from fairmd.lipids.core import System, initialize_databank
-from fairmd.lipids.experiment import ExperimentCollection
+from fairmd.lipids.experiment import ExperimentCollection, OPExperiment
 
 
 class QualSimulation(System):
@@ -215,7 +215,8 @@ class OPQualityEvaluator(QualityEvaluator):
 
         :return: dictionary of type {"nC nH": quality value}.
         """
-        exp_error = 0.02  # TODO: hardcoded error value, should be taken from experiment data when available
+        # TODO: hardcoded error value, should be taken from experiment data when available
+        exp_error = OPExperiment.DEFAULT_ERROR
 
         # union of keys in exp_op_data and sim_op_data
         all_keys = sorted(set(exp_op_data.keys()) | set(sim_op_data.keys()))


### PR DESCRIPTION
- [x] Generate OP dataset from experiments.
- [x] Generate OP dataset from simulations.

The PR is a shorter version of the all-dataset version #476. It's much shorter for review.
This PR: https://github.com/NMRLipids/BilayerData/pull/388 already uses this branch.

It has additional dependencies: `tables` and `unidecode`, and it has very simple usage:
```sh
(Databank) comcon1@tanteliss:~/repo/Databank/developer$ ./gen-op-dataset.py --help
fairmd-lipids 1.5.1.dev4+g37cd713e8 by NMRlipids Open Collaboration - GPL-3.0-or-later
FAIRMD Lipids is initialized from the folder: /home/comcon1/repo/Databank/Data
---------------------------------------------------------------
usage: gen-op-dataset.py [-h] [--exps] [--sims]

options:
  -h, --help  show this help message and exit
  --exps      Run experiments
  --sims      Run simulations
```

It will generate one or another dataset in HDF5 format.

<!-- readthedocs-preview databank start -->
----
📚 Documentation preview 📚: https://databank--491.org.readthedocs.build/

<!-- readthedocs-preview databank end -->