### PR TITLE
Add atomic point quality dataset generator

### DIFF
--- a/developer/gen-atomicq-dataset.py
+++ b/developer/gen-atomicq-dataset.py
@@ -13,6 +13,10 @@ class OPQDataError(Exception):
 
 
 class OPQDataStorer():
+
+
+    DEFAULT_OPQ_HDFNAME = "atomic-opq-dataset.h5"
+
     def __init__(self, s: System, lname: str) -> None:
         self._s = s
         self._lname = lname
@@ -143,7 +147,6 @@ class OPQDataStorer():
                 sample_storer.attrs[k] = v
 
 
-H5_QSIMS_MASTER = "atomic-opq-dataset.h5"
 
 
 def load_sims() -> None:
@@ -170,7 +173,7 @@ def load_sims() -> None:
             ods.average_experiment_data()
 
             ods.compute_q_points()
-            ods.store_to_hdf5(H5_QSIMS_MASTER)
+            ods.store_to_hdf5(OPQDataStorer.DEFAULT_OPQ_HDFNAME)
 
 
 if __name__ == "__main__":

--- a/developer/gen-atomicq-dataset.py
+++ b/developer/gen-atomicq-dataset.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from fairmd.lipids.api import get_OP
 from fairmd.lipids.core import System, initialize_databank
-from fairmd.lipids.experiment import ExperimentCollection
+from fairmd.lipids.experiment import ExperimentCollection, OPExperiment
 
 
 class OPQDataError(Exception):
@@ -16,7 +16,7 @@ class OPQDataStorer():
     def __init__(self, s: System, lname: str) -> None:
         self._s = s
         self._lname = lname
-        self._exp_opdicts = []
+        self._exp_opdicts: list[pd.DataFrame] = []
 
     def _cvt_op_df(self, opdict: dict, err_pos: int) -> pd.DataFrame:
         op_clean = pd.DataFrame(
@@ -25,7 +25,7 @@ class OPQDataStorer():
         smi2uname = self._get_smi2uname()
         for smid, uname in smi2uname.items():
             _c_dict = {
-                k: [v[0], 0.02 if err_pos >= len(v) else v[err_pos]]  # check
+                k: [v[0], OPExperiment.DEFAULT_ERROR if err_pos >= len(v) else v[err_pos]]  # check
                 for k, v in opdict.items()
                 if k.split()[0] == uname
             }
@@ -42,7 +42,11 @@ class OPQDataStorer():
                 op_clean.loc[len(op_clean)] = [smid, 1, vearr[0, 0], vearr[0, 1]]
                 op_clean.loc[len(op_clean)] = [smid, 2, vearr[1, 0], vearr[1, 1]]
             else:
-                msg = f"Unexpected number of H for {uname} in instance {self.ass_id} // {self._lname}: {_c_dict_len}. Cannot store."
+                msg = (
+                    f"Unexpected number of H for {uname} in "
+                    f"instance {self.ass_id} // {self._lname}: {_c_dict_len}."
+                    " Cannot store."
+                )
                 raise OPQDataError(msg)
         return op_clean.astype({"c": np.int64, "h": np.int64, "val": np.float64, "err": np.float64})
 
@@ -76,12 +80,12 @@ class OPQDataStorer():
     def average_experiment_data(self) -> None:
         """Average experimental OP data if we have more than one."""
         concdf = pd.concat(self._exp_opdicts, ignore_index=True)
-        self._exp_opdict = concdf.groupby(["c", "h"]).mean().reset_index()
+        self._exp_opdict_one: pd.DataFrame = concdf.groupby(["c", "h"]).mean().reset_index()
 
     def compute_q_points(self) -> None:
-        """Compute shift btw simulation and mean(exp) datapoints"""
+        """Compute mean(exp) datapoints and inherit sign from simulation OP value"""
         df1 = self._sim_op.merge(
-            self._exp_opdict,
+            self._exp_opdict_one,
             on=["c", "h"],
             how="inner",
             suffixes=("_s", "_e"),

--- a/developer/gen-atomicq-dataset.py
+++ b/developer/gen-atomicq-dataset.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+
+from abc import ABC
+
+import numpy as np
+import pandas as pd
+
+from fairmd.lipids.api import get_OP
+from fairmd.lipids.core import System, initialize_databank
+from fairmd.lipids.experiment import ExperimentCollection
+
+
+class OPQDataError(Exception):
+    """Our specific exception"""
+
+
+class OPQDataStorer(ABC):
+    def __init__(self, s: System, lname: str) -> None:
+        self._s = s
+        self._lname = lname
+
+    def _cvt_op_df(self, opdict: dict, err_pos: int) -> pd.DataFrame:
+        op_clean = pd.DataFrame(
+            columns=["c", "h", "val", "err"],
+        )
+        smi2uname = self._get_smi2uname()
+        for smid, uname in smi2uname.items():
+            _c_dict = {
+                k: [v[0], 0.02 if err_pos >= len(v) else v[err_pos]]  # check
+                for k, v in opdict.items()
+                if k.split()[0] == uname
+            }
+            _c_dict_len = len(_c_dict)
+            if _c_dict_len == 0:
+                continue
+            vearr = np.array([_c_dict.popitem()[1] for _ in range(_c_dict_len)])
+            if _c_dict_len == 1:  # one H
+                op_clean.loc[len(op_clean)] = [smid, 1, vearr[0, 0], vearr[0, 1]]
+            elif _c_dict_len == 3:  # three H. They are always symmetric.
+                op_clean.loc[len(op_clean)] = [smid, 1, np.mean(vearr[:, 0]), np.mean(vearr[:, 1])]
+            elif _c_dict_len == 2:  # four H. They could be asymmetric.
+                vearr = vearr[np.argsort(np.abs(vearr[:, 0]))]
+                op_clean.loc[len(op_clean)] = [smid, 1, vearr[0, 0], np.mean(vearr[0, 1])]
+                op_clean.loc[len(op_clean)] = [smid, 2, vearr[1, 0], np.mean(vearr[1, 1])]
+            else:
+                msg = f"Unexpected number of H for {uname} in instance {self.ass_id} // {self._lname}: {_c_dict_len}. Cannot store."
+                raise OPQDataError(msg)
+        return op_clean.astype({"c": np.int64, "h": np.int64, "val": np.float64, "err": np.float64})
+
+    def prepare_sim_dataframe(self) -> None:
+        """Prepare dataframe for storing."""
+        opdict = get_OP(self._s)[self._lname]
+        self._sim_op = self._cvt_op_df(opdict, 2)
+
+    @property
+    def ass_id(self) -> str:
+        """Get id of assoc object"""
+        return self._s["ID"]
+
+    def _get_smi2uname(self) -> dict:
+        mol = self._s.lipids[self._lname]
+        smiles = mol.metadata["bioschema_properties"]["smiles"]
+        print(smiles)
+        s2u = {}
+        for uname, aprops in mol.mapping_dict.items():
+            if "SMILEIDX" in aprops:
+                smid = int(aprops["SMILEIDX"])
+                s2u[smid] = uname
+        if not s2u:
+            # NO SMILEIDX. Cannot store.
+            msg = f"Instance {self.ass_id} // {self._lname} cannot be stored: we don't have SMILEIDX."
+            raise OPQDataError(msg)
+        return dict(sorted(s2u.items()))
+
+    def add_experiment_data(self, exp_opdict: dict) -> None:
+        """Add experimental OP data to the storer. We will use it for Q estimation."""
+        if not hasattr(self, "_exp_opdict"):
+            self._exp_opdicts = []
+        self._exp_opdicts.append(self._cvt_op_df(exp_opdict, 1))
+
+    def average_experiment_data(self) -> None:
+        """Average experimental OP data if we have more than one."""
+        concdf = pd.concat(self._exp_opdicts, ignore_index=True)
+        self._exp_opdict = concdf.groupby(["c", "h"]).mean().reset_index()
+
+    def compute_q_points(self) -> None:
+        """Compute shift btw simulation and mean(exp) datapoints"""
+        df1 = self._sim_op.merge(
+            self._exp_opdict,
+            on=["c", "h"],
+            how="inner",
+            suffixes=("_s", "_e"),
+        )
+        df1["val_e"] = df1["val_e"].abs() * np.sign(df1["val_s"])
+        self._qpoints = df1
+
+    def store_to_hdf5(self, hdf_fname: str) -> None:
+        """Store the record"""
+        _mcontent = self._s["COMPOSITION"]
+        mcontent = {"name": [], "inchikey": [], "number": [], "asymmetry": []}
+        for lname, lip in self._s.lipids.items():
+            ik = lip.metadata["bioschema_properties"]["inChIKey"]
+            cnt = _mcontent[lname]["COUNT"]
+            if isinstance(cnt, int):
+                asm = np.nan
+                cnt = [cnt / 2, cnt / 2]
+            else:
+                asm = cnt[0] / sum(cnt)
+            mcontent["name"] += [lname]
+            mcontent["inchikey"] += [ik]
+            mcontent["number"] += [sum(cnt) / 2]
+            mcontent["asymmetry"] += [asm]
+        hydration = self._s.get_hydration()
+        scontent = self._s.solution_composition(basis="molar")
+        temperature = self._s["TEMPERATURE"]
+        inchikey = self._s.lipids[self._lname].metadata["bioschema_properties"]["inChIKey"]
+        smiles = self._s.lipids[self._lname].metadata["bioschema_properties"]["smiles"]
+        ff_name = self._s.readme.get("FF", False)
+        # store all vars and df to the HDF5 table
+        group = f"SIM_{self._s['ID']}__{self._lname}"
+        with pd.HDFStore(hdf_fname, "a") as store:
+            # DataFrame table
+            store.put(f"{group}/op_values", self._qpoints, format="table", data_columns=True)
+            store.put(f"{group}/simulation_table", pd.DataFrame(mcontent), format="table", data_columns=True)
+            # Metadata attributes - I
+            op_storer = store.get_storer(f"{group}/op_values")
+            upd_attr = {
+                "inchikey": inchikey,
+                "smiles": smiles,
+                "fmdl_simid": self._s["ID"],
+            }
+            for k, v in upd_attr.items():
+                op_storer.attrs[k] = v
+            # -//- II
+            sample_storer = store.get_storer(f"{group}/simulation_table")
+            upd_attr = {
+                "temperature": temperature,
+                "hydration": hydration,
+                "solution": ", ".join([f"{k:<25} {v * 100:>6.1f}%" for k, v in sorted(scontent.items())]),
+            }
+            if ff_name:
+                upd_attr["ff_name"] = ff_name
+            for k, v in upd_attr.items():
+                sample_storer.attrs[k] = v
+
+
+H5_QSIMS_MASTER = "atomic-opq-dataset.h5"
+
+def load_sims() -> None:
+    print("Generating OP dataset from simulations.")
+    exps = ExperimentCollection.load_from_data("OPExperiment")
+    sims = initialize_databank()
+    for sim in sims:
+        paired_opedict = sim["EXPERIMENT"].get("ORDERPARAMETER", {})
+        for lname in sim.lipids:
+            if len(paired_opedict.get(lname, [])) == 0:
+                continue
+            print(sim)
+
+            ods = OPQDataStorer(sim, lname)
+            try:
+                ods.prepare_sim_dataframe()
+            except OPQDataError as e:
+                print("ERROR: ", e)
+                continue
+
+            for expid in paired_opedict[lname]:
+                _exp = exps.loc(expid)
+                ods.add_experiment_data(_exp.data[lname])
+            ods.average_experiment_data()
+
+            ods.compute_q_points()
+            ods.store_to_hdf5(H5_QSIMS_MASTER)
+
+
+if __name__ == "__main__":
+    load_sims()

--- a/developer/gen-atomicq-dataset.py
+++ b/developer/gen-atomicq-dataset.py
@@ -18,6 +18,7 @@ class OPQDataStorer(ABC):
     def __init__(self, s: System, lname: str) -> None:
         self._s = s
         self._lname = lname
+        self._exp_opdicts = []
 
     def _cvt_op_df(self, opdict: dict, err_pos: int) -> pd.DataFrame:
         op_clean = pd.DataFrame(
@@ -74,8 +75,6 @@ class OPQDataStorer(ABC):
 
     def add_experiment_data(self, exp_opdict: dict) -> None:
         """Add experimental OP data to the storer. We will use it for Q estimation."""
-        if not hasattr(self, "_exp_opdict"):
-            self._exp_opdicts = []
         self._exp_opdicts.append(self._cvt_op_df(exp_opdict, 1))
 
     def average_experiment_data(self) -> None:
@@ -145,6 +144,7 @@ class OPQDataStorer(ABC):
 
 
 H5_QSIMS_MASTER = "atomic-opq-dataset.h5"
+
 
 def load_sims() -> None:
     print("Generating OP dataset from simulations.")

--- a/developer/gen-atomicq-dataset.py
+++ b/developer/gen-atomicq-dataset.py
@@ -39,10 +39,10 @@ class OPQDataStorer(ABC):
                 op_clean.loc[len(op_clean)] = [smid, 1, vearr[0, 0], vearr[0, 1]]
             elif _c_dict_len == 3:  # three H. They are always symmetric.
                 op_clean.loc[len(op_clean)] = [smid, 1, np.mean(vearr[:, 0]), np.mean(vearr[:, 1])]
-            elif _c_dict_len == 2:  # four H. They could be asymmetric.
+            elif _c_dict_len == 2:  # two H. They could be asymmetric.
                 vearr = vearr[np.argsort(np.abs(vearr[:, 0]))]
-                op_clean.loc[len(op_clean)] = [smid, 1, vearr[0, 0], np.mean(vearr[0, 1])]
-                op_clean.loc[len(op_clean)] = [smid, 2, vearr[1, 0], np.mean(vearr[1, 1])]
+                op_clean.loc[len(op_clean)] = [smid, 1, vearr[0, 0], vearr[0, 1]]
+                op_clean.loc[len(op_clean)] = [smid, 2, vearr[1, 0], vearr[1, 1]]
             else:
                 msg = f"Unexpected number of H for {uname} in instance {self.ass_id} // {self._lname}: {_c_dict_len}. Cannot store."
                 raise OPQDataError(msg)

--- a/developer/gen-atomicq-dataset.py
+++ b/developer/gen-atomicq-dataset.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from abc import ABC
-
 import numpy as np
 import pandas as pd
 
@@ -14,7 +12,7 @@ class OPQDataError(Exception):
     """Our specific exception"""
 
 
-class OPQDataStorer(ABC):
+class OPQDataStorer():
     def __init__(self, s: System, lname: str) -> None:
         self._s = s
         self._lname = lname
@@ -34,7 +32,7 @@ class OPQDataStorer(ABC):
             _c_dict_len = len(_c_dict)
             if _c_dict_len == 0:
                 continue
-            vearr = np.array([_c_dict.popitem()[1] for _ in range(_c_dict_len)])
+            vearr = np.array(list(_c_dict.values()))
             if _c_dict_len == 1:  # one H
                 op_clean.loc[len(op_clean)] = [smid, 1, vearr[0, 0], vearr[0, 1]]
             elif _c_dict_len == 3:  # three H. They are always symmetric.
@@ -60,8 +58,6 @@ class OPQDataStorer(ABC):
 
     def _get_smi2uname(self) -> dict:
         mol = self._s.lipids[self._lname]
-        smiles = mol.metadata["bioschema_properties"]["smiles"]
-        print(smiles)
         s2u = {}
         for uname, aprops in mol.mapping_dict.items():
             if "SMILEIDX" in aprops:


### PR DESCRIPTION
This script generates the point quality dataset of the following schema:

| c | h | val_s | err_s  | val_e | err_e |
|--|--|--|--|--|--|
| Carbon SMILE ID | H ID | OP value (simulatioon) | err | OP value (experiment), with the sign from the simulation |err |

For a single carbon atom, if proton's OP value cannot be different (there is only one proton or 3 protons), then H ID is only "1" and only single value is used. 

For CH2 groups, protons can be different, we assign 1 to be proton with smaller absolute OP and 2 with larger.
This clears the problem of the uncertainty of chirality that we have for some atoms.

We do not trust the sign of the OP value in any experiments. Signs are always inherited from the simulation.

All values from all experiments are averaged using only `c,h` pair as a key.

<!-- readthedocs-preview databank start -->
----
📚 Documentation preview 📚: https://databank--495.org.readthedocs.build/

<!-- readthedocs-preview databank end -->