### PR TITLE
Fix Docker pull command in README

### DIFF
--- a/developer/docker/README.md
+++ b/developer/docker/README.md
@@ -28,7 +28,7 @@ Go to the directory where you have the fairmd-lipids repository. Then,
 
 1. Download the latest fairmd-lipids core image:
    ```
-   docker pull fairmd-lipids/core:latest
+   docker pull nmrlipids/core:latest
    ```
 
 2. Alternatively the Docker image can be built locally:


### PR DESCRIPTION
Fixes small error in the readme related to Docker. 

<!-- readthedocs-preview databank start -->
----
📚 Documentation preview 📚: https://databank--502.org.readthedocs.build/

<!-- readthedocs-preview databank end -->