### PR TITLE
Fix tests-develop test

### DIFF
--- a/tests/develop/test_autocomplete_metadata.py
+++ b/tests/develop/test_autocomplete_metadata.py
@@ -1,4 +1,3 @@
-from importlib.resources import files
 import importlib.util
 import json
 import os
@@ -76,12 +75,16 @@ def test_autocomplete_output_is_schema_compliant(tmp_path, monkeypatch):
     mod.main()
 
     generated = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
-    with (
-        files("fairmd.lipids.schema_validation.schema")
-        .joinpath("metadata_schema.json")
-        .open("r", encoding="utf-8") as f
-    ):
-        schema = json.load(f)
+    schema_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "fairmd"
+        / "lipids"
+        / "schema_validation"
+        / "schema"
+        / "metadata_schema.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
 
     errors = sorted(Draft7Validator(schema).iter_errors(generated), key=lambda e: e.path)
     assert not errors


### PR DESCRIPTION
This PR fixes regression #508 introduced in #506 by loading fairmd.lipids module during a test stage which the test wasn't designed for. 

When imported the fairmd.lipids package does some heavy lifting, whose __init__.py raises RuntimeError when FMDL_DATA_PATH points to a non-existent folder. Develop tests shouldn't trigger that heavy package initialization, so loading the schema from the filesystem keeps them isolated.

Now loading the schema directly again. If you think, loading the package initialization is necessary, you need to provide it with the proper environment in the test.

(Btw, did I mention that unconditional loading of data from an environment variable was a bad idea? __init__ should be lazy loading and side-effect free ) 

<!-- readthedocs-preview databank start -->
----
📚 Documentation preview 📚: https://databank--510.org.readthedocs.build/

<!-- readthedocs-preview databank end -->