### PR TITLE
Fix dev-tests and make them following the same mechanism of importing as unit-tests

### DIFF
--- a/.github/workflows/tests-develop.yml
+++ b/.github/workflows/tests-develop.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "developer/**"
       - "tests/develop/**"
+      - "tests/conftest.py"
       - "tox.ini"
       - "pyproject.toml"
       - "MANIFEST.in"
@@ -14,6 +15,7 @@ on:
     paths:
       - "developer/**"
       - "tests/develop/**"
+      - "tests/conftest.py"
       - "tox.ini"
       - "pyproject.toml"
       - "MANIFEST.in"

--- a/.github/workflows/tests-min.yml
+++ b/.github/workflows/tests-min.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "src/**"
       - "tests/package/**"
+      - "tests/conftest.py"
       - "tox.ini"
       - "pyproject.toml"
       - "MANIFEST.in"
@@ -14,6 +15,7 @@ on:
     paths:
       - "src/**"
       - "tests/package/**"
+      - "tests/conftest.py"
       - "tox.ini"
       - "pyproject.toml"
       - "MANIFEST.in"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def header_module_scope(request):
         cmdopt = request.config.getoption("--cmdopt")
         sim_key = cmdopt if cmdopt in SIM_MAP else "nodata"
 
-    data_root = os.path.join(os.path.dirname(os.path.dirname(__file__)), "ToyData")
+    data_root = os.path.join(os.path.dirname(__file__), "ToyData")
     os.environ["FMDL_DATA_PATH"] = data_root
     sim_dir = SIM_MAP[sim_key]
     if sim_dir:

--- a/tests/develop/test_autocomplete_metadata.py
+++ b/tests/develop/test_autocomplete_metadata.py
@@ -13,7 +13,7 @@ from jsonschema import Draft7Validator
 # These tests exercise developer/autocomplete_metadata.py, which lives in the
 # `developer/` folder and is not part of the distributed package. Mark the whole
 # module as `develop` so it is isolated from the package test suite.
-pytestmark = pytest.mark.develop
+pytestmark = [pytest.mark.develop, pytest.mark.nodata]
 
 
 def load_autocomplete_module():


### PR DESCRIPTION
This scheme allows develop-scripts and their tests to import from fairmd.lipids data using ToyData as a data folder. It's not very important for the current particular test initiated by @mdondrup; however, it's of highly importance for future testing of other scripts in `develop` because we allow (and recommend) importing `fairmd.lipids` from develop scripts.

<!-- readthedocs-preview databank start -->
----
📚 Documentation preview 📚: https://databank--511.org.readthedocs.build/

<!-- readthedocs-preview databank end -->